### PR TITLE
lint: use babel-eslint parser

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,6 @@
 {
   "extends": "airbnb/base",
+  "parser": "babel-eslint",
 
   "rules": {
     "comma-dangle": [2, "never"]

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.3.17",
+    "babel-eslint": "^5.0.0-beta10",
     "babel-plugin-transform-class-properties": "^6.5.2",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-export-extensions": "^6.5.0",


### PR DESCRIPTION
Fixes issues where the linter doesn't know how to parse a fancy ES-future feature we use.
