### PR TITLE
Accept a bunch of stuff for Redis connection config

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -27,10 +27,18 @@ export default class UWaveServer extends EventEmitter {
     this.server = http.createServer(this.app);
 
     this.mongo = mongoose.createConnection();
-    this.redis = new Redis(config.redis.port, config.redis.host, {
-      ...config.redis.options,
-      lazyConnect: true
-    });
+    if (typeof config.redis === 'string') {
+      this.redis = new Redis(config.redis, { lazyConnect: true });
+    } else if (typeof config.redis === 'object') {
+      this.redis = new Redis(config.redis.port, config.redis.host, {
+        ...config.redis.options,
+        lazyConnect: true
+      });
+    } else if (config.redis instanceof Redis) {
+      this.redis = config.redis;
+    } else {
+      this.redis = new Redis({ lazyConnect: true });
+    }
 
     models()(this);
 


### PR DESCRIPTION
Earlier the `redis` config option only accepted a custom object format. This patch accepts path URLs, existing IORedis instances, the custom object format, and nothing (defaults).

Todo: read the IORedis docs once more to make sure that all its options are covered by these few formats.

Other todo: Put this in a `parseOptions` method instead? The `UWaveServer` constructor is starting to get a bit messy.
