### PR TITLE
models: remove separate "salt" property from Authentication model

### DIFF
--- a/src/models/Authentication.js
+++ b/src/models/Authentication.js
@@ -9,7 +9,6 @@ export default () => {
       user: { type: Types.ObjectId, ref: 'User' },
       email: { type: String, max: 254, required: true, unique: true },
       hash: { type: String, required: true },
-      salt: { type: String, required: true },
       validated: { type: Boolean, default: false }
     };
   }


### PR DESCRIPTION
It'll be embedded in the "hash" property instead (bcrypt hype!)

For use with goto-bus-stop/u-wave-api-v1#59
