### PR TITLE
Accept a bunch of stuff for Mongoose connection config

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "get-artist-title": "^0.1.0",
     "googleapis": "^2.1.7",
     "ioredis": "^1.9.0",
+    "lodash.isplainobject": "^4.0.3",
     "mongoose": "^4.1.6",
     "mongoose-model-decorators": "^0.2.1",
     "object-values": "^1.0.0",


### PR DESCRIPTION
Earlier the `mongo` config option only accepted a custom object format. This patch accepts Mongoose URIs, connection instances, Mongoose `createConnection` arguments (intended for use with JSON config files), and nothing (default to `mongodb://localhost:27017/uwave`.)
