### PR TITLE
sources: improve search results for YT URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "debug": "^2.2.0",
     "express": "^4.13.3",
     "get-artist-title": "^0.1.0",
+    "get-youtube-id": "^1.0.0",
     "googleapis": "^2.1.7",
     "ioredis": "^1.9.0",
     "lodash.isplainobject": "^4.0.3",

--- a/src/sources/youtube.js
+++ b/src/sources/youtube.js
@@ -1,4 +1,5 @@
 import Promise from 'bluebird';
+import getYouTubeID from 'get-youtube-id';
 import parseIsoDuration from 'parse-iso-duration';
 import getArtistTitle, { fallBackToArtist } from 'get-artist-title';
 import chunk from 'chunk';
@@ -91,7 +92,10 @@ export default function youTubeSource(uw, opts = {}) {
       ...defaultSearchOptions,
       ...searchOptions,
       ...params,
-      q: query,
+      // When searching for a video URL, we want to search for the video ID
+      // only, because search results are very inconsistent with some types of
+      // URLs.
+      q: getYouTubeID(query, { fuzzy: false }) || query,
       pageToken: page
     });
 


### PR DESCRIPTION
Extracts the YT video ID from URL searches, and only searches for the video ID. One case where this is :100: is videos in playlists, because querying the API for a URL like:

https://www.youtube.com/watch?v=3LDJDgIxu98&index=16&list=PL7yDj1r_U1o5TRLcSVVxXTncRAiq1oDmf

Yields no results, but querying for `3LDJDgIxu98` does.
