### PR TITLE
core: remove HTTP server

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,0 @@
-var UwaveServer = require('./lib/server').default;
-
-module.exports = function uwave(opts) {
-  return new UwaveServer(opts);
-};
-
-module.exports.Server = UwaveServer;

--- a/package.json
+++ b/package.json
@@ -4,15 +4,14 @@
   "description": "Room server node for üWave.",
   "license": "MIT",
   "repository": "u-wave/u-wave-server",
+  "main": "lib/index.js",
   "engines": {
     "node": ">= 4.0"
   },
   "dependencies": {
     "bluebird": "^2.10.0",
-    "body-parser": "^1.13.3",
     "chunk": "0.0.2",
     "debug": "^2.2.0",
-    "express": "^4.13.3",
     "get-artist-title": "^0.2.1",
     "get-youtube-id": "^1.0.0",
     "googleapis": "^2.1.7",

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,7 @@
+import Uwave from './Uwave';
+
+module.exports = function uwave(opts) {
+  return new Uwave(opts);
+};
+
+module.exports.Uwave = Uwave;

--- a/test/server.js
+++ b/test/server.js
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 
-import Server from '../lib/server';
+import uwave, { Uwave } from '../';
 
-describe('üWave Server', () => {
-  it('can instantiate a Server object', () => {
+describe('üWave Core', () => {
+  it('can create a üWave instance', () => {
     expect(
-      new Server(require('./test-server-config'))
-    ).to.be.instanceOf(Server);
+      uwave(require('./test-server-config'))
+    ).to.be.instanceOf(Uwave);
   });
 });

--- a/test/sources.js
+++ b/test/sources.js
@@ -3,13 +3,13 @@ import asPromised from 'chai-as-promised';
 
 chai.use(asPromised);
 
-import Server from '../lib/server';
+import uwave from '../';
 import Source from '../lib/Source';
 
 describe('Media Sources', () => {
   let server;
   beforeEach(() => {
-    server = new Server(require('./test-server-config'));
+    server = uwave(require('./test-server-config'));
   });
 
   class TestSource {


### PR DESCRIPTION
This makes üWave core agnostic about how it's used.

Server hosts who want to run an HTTP üWave server will now have to create their own HTTP server instance explicitly.
