### PR TITLE
booth: fix waitlist sync during quick subsequent advances

### DIFF
--- a/src/plugins/booth.js
+++ b/src/plugins/booth.js
@@ -187,7 +187,6 @@ export class Booth {
 
     if (next) {
       await next.save();
-      await this.play(next);
     } else {
       this.maybeStop();
     }
@@ -197,6 +196,7 @@ export class Booth {
     if (next) {
       await this.update(next);
       await this.cyclePlaylist(next.playlist);
+      await this.play(next);
     } else {
       await this.clear();
     }


### PR DESCRIPTION
The advance timer was started about halfway through the advance
sequence, so if one play was very short (say, 0 seconds) the timer
could fire before the advance sequence was complete. Then,
`cycleWaitlist()` was called twice but with the _same_ `previous`
parameter, leading the same user to be added back to the waitlist
twice.
