### PR TITLE
chat: Migrate chat and mutes from u-wave-api-v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "gulp-newer": "^1.1.0",
     "gulp-util": "^3.0.7",
     "mocha": "^2.4.5",
+    "sinon": "^1.17.3",
+    "sinon-chai": "^2.8.0",
     "through2": "^2.0.1"
   },
   "scripts": {

--- a/src/Uwave.js
+++ b/src/Uwave.js
@@ -12,6 +12,7 @@ import soundCloudSource from './sources/soundcloud';
 
 import models from './models';
 import booth from './plugins/booth';
+import chat from './plugins/chat';
 
 mongoose.Promise = Promise;
 
@@ -46,6 +47,7 @@ export default class UWaveServer extends EventEmitter {
 
     this.use(models());
     this.use(booth());
+    this.use(chat());
 
     process.nextTick(() => {
       this.emit('started');
@@ -96,6 +98,14 @@ export default class UWaveServer extends EventEmitter {
   advance(opts = {}) {
     this.log('advance', opts);
     return this.booth.advance(opts);
+  }
+
+  sendChat(user, message) {
+    return this.chat.send(user, message);
+  }
+
+  deleteChat(filter = {}, opts = {}) {
+    return this.chat.delete(filter, opts);
   }
 
   /**

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -44,18 +44,29 @@ export default uw => {
       banned: new BannedSchema()
     };
 
+    @pre('validate')
+    makeSlug() {
+      this.slug = slugify(this.username, { lang: this.language });
+    }
+
     getActivePlaylistID(): Promise<string> {
       return uw.redis.get(`playlist:${this.id}`);
     }
 
     async getActivePlaylist(): Promise {
       const playlistID = await this.getActivePlaylistID();
-      return await this.model('Playlist').findOne({ _id: playlistID });
+      return await this.model('Playlist').findById(playlistID);
     }
 
-    @pre('validate')
-    makeSlug() {
-      this.slug = slugify(this.username, { lang: this.language });
+    async mute(...args): Promise {
+      return await uw.chat.mute(this, ...args);
+    }
+    async unmute(...args): Promise {
+      return await uw.chat.unmute(this, ...args);
+    }
+
+    async isMuted(): Promise<boolean> {
+      return await uw.chat.isMuted(this);
     }
   }
 

--- a/src/plugins/chat.js
+++ b/src/plugins/chat.js
@@ -1,0 +1,79 @@
+const defaultOptions = {
+  maxLength: 300
+};
+
+export class Chat {
+  chatId = Date.now();
+
+  constructor(uw, options = {}) {
+    this.uw = uw;
+
+    this.options = {
+      ...defaultOptions,
+      ...options
+    };
+  }
+
+  async mute(user, duration, opts = {}) {
+    await this.uw.redis.set(
+      `mute:${user.id}`, opts.moderator.id,
+      'PX', duration
+    );
+
+    this.uw.publish('chat:mute', {
+      moderatorID: opts.moderator.id,
+      userID: user.id,
+      duration
+    });
+  }
+
+  async unmute(user, opts = {}) {
+    await this.uw.redis.del(`mute:${user.id}`);
+
+    this.uw.publish('chat:unmute', {
+      moderatorID: opts.moderator.id,
+      userID: user.id
+    });
+  }
+
+  isMuted(user) {
+    return this.uw.redis.exists(`mute:${user.id}`);
+  }
+
+  truncate(message) {
+    return message.slice(0, this.options.maxLength);
+  }
+
+  async send(user, message) {
+    if (await this.isMuted(user)) {
+      return;
+    }
+
+    this.chatID++;
+
+    this.uw.publish('chat:message', {
+      id: `${user.id}-${this.chatID}`,
+      userID: user.id,
+      message: this.truncate(message),
+      timestamp: Date.now()
+    });
+  }
+
+  delete(filter = {}, opts = {}) {
+    const deletion = {
+      filter: typeof filter === 'string' ? { id: filter } : filter
+    };
+
+    if (opts.moderator) {
+      deletion.moderatorID = opts.moderator.id;
+    }
+
+    this.uw.publish('chat:delete', deletion);
+  }
+}
+
+export default function chat(opts = {}) {
+  return uw => {
+    uw.chat = new Chat(uw, opts); // eslint-disable-line no-param-reassign
+  };
+}

--- a/test/chat.js
+++ b/test/chat.js
@@ -1,0 +1,52 @@
+import chai, { expect } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+
+chai.use(sinonChai);
+
+import chatPlugin from '../src/plugins/chat';
+
+function createUwaveWithChatTest() {
+  const uw = {
+    redis: {
+      exists: sinon.stub().returns(false)
+    },
+    publish: sinon.spy()
+  };
+
+  chatPlugin()(uw);
+
+  return uw;
+}
+
+describe('Chat', () => {
+  let uw;
+
+  beforeEach(() => {
+    uw = createUwaveWithChatTest();
+  });
+
+  it('can broadcast chat messages', async () => {
+    await uw.chat.send({ id: 1 }, 'Message text');
+    expect(uw.publish).to.have.been.calledWithMatch('chat:message', {
+      userID: 1,
+      message: 'Message text'
+    });
+  });
+
+  it('does not broadcast chat messages from muted users', async () => {
+    const stub = sinon.stub(uw.chat, 'isMuted');
+    stub.withArgs({ id: 1 }).returns(false);
+    stub.withArgs({ id: 2 }).returns(true);
+
+    await uw.chat.send({ id: 1 }, 'Message text');
+    await uw.chat.send({ id: 2 }, 'Message text');
+
+    expect(uw.publish).to.have.been.calledWithMatch('chat:message', {
+      userID: 1
+    });
+    expect(uw.publish).to.not.have.been.calledWithMatch('chat:message', {
+      userID: 2
+    });
+  });
+});


### PR DESCRIPTION
Adds a chat plugin. Most of the code is the same as it was in u-wave-api-v1, but in a class instead of in separate controller functions.

There are two more changes though:
- Chat messages now get a unique ID
- Deleting chat works using a Filter object instead of the separate `deleteChat{byID,byUser}` methods. Ideally clients would delete every chat message that "matches" the filter object (eg. `{ userID: 1 }` would match all messages by user #1)
