### PR TITLE
playlists: fix loading defaults for new playlist items

### DIFF
--- a/src/plugins/playlists.js
+++ b/src/plugins/playlists.js
@@ -228,7 +228,7 @@ export class PlaylistsRepository {
       const knownMedias = await Media.find({
         sourceType,
         sourceID: { $in: sourceItems.map(item => item.sourceID) }
-      }).select({ sourceID: 1 });
+      });
 
       const unknownMediaIDs = [];
       sourceItems.forEach(item => {


### PR DESCRIPTION
Load the full Media documents when adding new playlist items of
existing Media. Earlier this query assumed that we only needed to
_create_ new Media documents later for playlist items of _new_
Media, but we also need to copy playlist item defaults (in
particular, start/end times), so just the sourceType/sourceID is
not enough.
