### PR TITLE
playlists: fix finding relevant Media models for new playlist items

### DIFF
--- a/src/plugins/playlists.js
+++ b/src/plugins/playlists.js
@@ -232,7 +232,7 @@ export class PlaylistsRepository {
 
       const unknownMediaIDs = [];
       sourceItems.forEach(item => {
-        if (!knownMedias.some(media => media.sourceID === item.sourceID)) {
+        if (!knownMedias.some(media => media.sourceID === String(item.sourceID))) {
           unknownMediaIDs.push(item.sourceID);
         }
       });
@@ -245,7 +245,7 @@ export class PlaylistsRepository {
 
       const itemsWithMedia = sourceItems.map(item => toPlaylistItem(
         item,
-        allMedias.find(media => media.sourceID === item.sourceID)
+        allMedias.find(media => media.sourceID === String(item.sourceID))
       ));
       playlistItems.push(...itemsWithMedia);
     }


### PR DESCRIPTION
Media models always have a String property "sourceID", but not all
media sources use Strings for source IDs. This patch makes sure
that all media source IDs of new items are treated as strings, so
they can be linked to their global Media models.

Fixes adding tracks from the SoundCloud media source.
