### PR TITLE
import: fix adding items to imported playlist

### DIFF
--- a/src/sources/ImportContext.js
+++ b/src/sources/ImportContext.js
@@ -27,7 +27,7 @@ export default class ImportContext {
     );
 
     if (rawItems.length > 0) {
-      await this.addPlaylistItems(playlist, rawItems);
+      await playlist.addItems(rawItems);
     }
 
     return playlist;


### PR DESCRIPTION
`this.addPlaylistItems` was a leftover from before playlist management was in -core
