### PR TITLE
Add waitlist

### DIFF
--- a/src/Uwave.js
+++ b/src/Uwave.js
@@ -10,6 +10,7 @@ import Source from './Source';
 
 import models from './models';
 import booth from './plugins/booth';
+import waitlist from './plugins/waitlist';
 import chat from './plugins/chat';
 import motd from './plugins/motd';
 import playlists from './plugins/playlists';
@@ -44,6 +45,7 @@ export default class UWaveServer extends EventEmitter {
 
     this.use(models());
     this.use(booth());
+    this.use(waitlist());
     this.use(chat());
     this.use(motd());
     this.use(playlists());

--- a/src/plugins/waitlist.js
+++ b/src/plugins/waitlist.js
@@ -1,0 +1,67 @@
+/**
+ *
+ */
+export class CyclingQueue {
+  list = [];
+
+  constructor(uw) {
+    this.uw = uw;
+  }
+
+  publishUpdate() {
+    this.uw.publish('waitlist:update', this.list);
+  }
+
+  async peek() {
+    const { users } = this.uw;
+    const first = await this.uw.redis.lindex('waitlist', 0);
+    const id = first || await this.uw.redis.get('waitlist:current');
+    if (!id) {
+      return null;
+    }
+    return await users.getUser(id);
+  }
+
+  async cycle() {
+    const previous = this.list.shift();
+    if (previous) {
+      this.list.push(previous);
+    }
+    this.publishUpdate();
+  }
+
+  async add(user) {
+    const { users } = this.uw;
+    this.list.push(await users.getUser(user));
+    this.publishUpdate();
+  }
+
+  async remove(user) {
+    const id = typeof user === 'object' ? user.id : user;
+    this.list = this.list.filter(waiting => waiting.id !== id);
+    this.publishUpdate();
+  }
+
+  async clear(opts = {}) {
+    await this.uw.redis.del('waitlist');
+    this.uw.publish('waitlist:clear', opts);
+  }
+
+  async current() {
+    const { redis, users } = this.uw;
+    const id = await redis.get('waitlist:current');
+    return id ? await users.getUser(id) : null;
+  }
+
+  async users() {
+    const { redis, users } = this.uw;
+    const waitlist = await redis.lrange('waitlist', 0, -1)
+    return await users.getUsers(waitlist);
+  }
+}
+
+export default function waitlist() {
+  return uw => {
+    uw.waitlist = new CyclingQueue(uw); // eslint-disable-line no-param-reassign
+  };
+}

--- a/src/plugins/waitlist.js
+++ b/src/plugins/waitlist.js
@@ -31,9 +31,14 @@ export class CyclingQueue {
   }
 
   async add(user) {
-    const { users } = this.uw;
+    const { booth, users } = this.uw;
     this.list.push(await users.getUser(user));
-    this.publishUpdate();
+    const entry = await booth.getCurrentEntry();
+    if (!entry) {
+      await booth.advance();
+    } else {
+      this.publishUpdate();
+    }
   }
 
   async remove(user) {


### PR DESCRIPTION
Adds a default waitlist plugin. (A cycling queue, like plug.dj.)

Todo:
- Have the `peek()` method return the next history entry, so the waitlist will pick both the next DJ and the DJ's next song.
