### PR TITLE
test: add Mockgoose, move test configuration to own file

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "gulp-util": "^3.0.7",
     "gulp-watch": "^4.3.5",
     "mocha": "^2.4.5",
+    "mockgoose": "^6.0.6",
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0",
     "through2": "^2.0.1"

--- a/test/chat.js
+++ b/test/chat.js
@@ -1,8 +1,5 @@
-import chai, { expect } from 'chai';
+import { expect } from 'chai';
 import sinon from 'sinon';
-import sinonChai from 'sinon-chai';
-
-chai.use(sinonChai);
 
 import chatPlugin from '../src/plugins/chat';
 

--- a/test/init.js
+++ b/test/init.js
@@ -1,0 +1,20 @@
+import { promisify } from 'bluebird';
+import chai from 'chai';
+import asPromised from 'chai-as-promised';
+import sinonChai from 'sinon-chai';
+import mockgoose from 'mockgoose';
+import mongoose from 'mongoose';
+
+chai.use(asPromised);
+chai.use(sinonChai);
+
+beforeEach(async () => {
+  await mockgoose(mongoose);
+  await mongoose.connect('mongodb://localhost/test');
+});
+afterEach(async () => {
+  // Clear mongoose state
+  mongoose.models = {};
+  mongoose.modelSchemas = {};
+  await promisify(mongoose.unmock)();
+});

--- a/test/sources.js
+++ b/test/sources.js
@@ -1,7 +1,4 @@
-import chai, { expect } from 'chai';
-import asPromised from 'chai-as-promised';
-
-chai.use(asPromised);
+import { expect } from 'chai';
 
 import uwave from '../';
 import Source from '../lib/Source';


### PR DESCRIPTION
Use mockgoose so we can test stuff without ruining people's own MongoDB instances.

I put the mocha+mockgoose config in its own file because it's using the global mocha before/after handlers, and other test files will all be more specific. I also put the existing chai config in there because that config applies globally anyway, so doing it in test-specific files is a bit confusing.
