### PR TITLE
history: Implement retrieving history in -core.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "bcrypt": "^1.0.0",
     "bluebird": "^3.4.6",
+    "clamp": "^1.0.1",
     "debug": "^2.6.0",
     "escape-string-regexp": "^1.0.5",
     "ioredis": "^2.4.0",

--- a/src/Uwave.js
+++ b/src/Uwave.js
@@ -7,6 +7,7 @@ import values from 'object-values';
 import isPlainObject from 'lodash/isPlainObject';
 
 import Source from './Source';
+import Page from './Page';
 
 import models from './models';
 import booth from './plugins/booth';
@@ -14,6 +15,7 @@ import chat from './plugins/chat';
 import motd from './plugins/motd';
 import playlists from './plugins/playlists';
 import users from './plugins/users';
+import history from './plugins/history';
 import acl from './plugins/acl';
 
 mongoose.Promise = Promise;
@@ -55,6 +57,7 @@ export default class UWaveServer extends EventEmitter {
       this.use(motd());
       this.use(playlists());
       this.use(users());
+      this.use(history());
       this.use(acl());
     }
 
@@ -109,6 +112,10 @@ export default class UWaveServer extends EventEmitter {
   advance(opts = {}) {
     this.log('advance', opts);
     return this.booth.advance(opts);
+  }
+
+  getHistory(pagination = {}): Promise<Page> {
+    return this.history.getRoomHistory(pagination);
   }
 
   sendChat(user, message) {
@@ -269,8 +276,8 @@ export default class UWaveServer extends EventEmitter {
   }
 
   /**
-  * Stop this üWave instance.
-  */
+   * Stop this üWave instance.
+   */
   async stop() {
     this.emit('stop');
 

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -2,6 +2,8 @@ import mongoose from 'mongoose';
 import { createSchema, pre } from 'mongoose-model-decorators';
 import slugify from 'speakingurl';
 
+import Page from '../Page';
+
 const Types = mongoose.Schema.Types;
 
 export default function userModel() {
@@ -91,6 +93,10 @@ export default function userModel() {
 
       createPlaylist(props): Promise {
         return uw.playlists.createPlaylist(this, props);
+      }
+
+      getPlayHistory(pagination = {}): Promise<Page> {
+        return uw.history.getUserHistory(this, pagination);
       }
 
       async mute(...args): Promise {

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -95,7 +95,7 @@ export default function userModel() {
         return uw.playlists.createPlaylist(this, props);
       }
 
-      getPlayHistory(pagination = {}): Promise<Page> {
+      getHistory(pagination = {}): Promise<Page> {
         return uw.history.getUserHistory(this, pagination);
       }
 

--- a/src/plugins/history.js
+++ b/src/plugins/history.js
@@ -1,0 +1,57 @@
+import clamp from 'clamp';
+
+import Page from '../Page';
+
+const DEFAULT_PAGE_SIZE = 50;
+const MAX_PAGE_SIZE = 100;
+
+export class HistoryRepository {
+  constructor(uw) {
+    this.uw = uw;
+  }
+
+  get HistoryEntry() {
+    return this.uw.model('History');
+  }
+
+  async getHistory(filter, pagination = {}) {
+    const offset = pagination.offset || 0;
+    const size = clamp(
+      'limit' in pagination ? pagination.limit : DEFAULT_PAGE_SIZE,
+      0, MAX_PAGE_SIZE
+    );
+
+    const total = await this.HistoryEntry.where(filter).count();
+    const results = await this.HistoryEntry.where(filter)
+      .sort({ playedAt: -1 })
+      .skip(offset)
+      .limit(size)
+      .populate('media.media user');
+
+    return new Page(results, {
+      pageSize: pagination ? pagination.limit : null,
+      filtered: total,
+      total,
+      current: { offset, limit: size },
+      next: pagination ? { offset: offset + size, limit: size } : null,
+      previous: offset > 0
+        ? { offset: Math.max(offset - size, 0), limit: size }
+        : null,
+      results
+    });
+  }
+
+  getRoomHistory(pagination = {}) {
+    return this.getHistory({}, pagination);
+  }
+
+  getUserHistory(user, pagination = {}) {
+    return this.getHistory({ user: user._id }, pagination);
+  }
+}
+
+export default function history() {
+  return (uw) => {
+    uw.history = new HistoryRepository(uw); // eslint-disable-line no-param-reassign
+  };
+}


### PR DESCRIPTION
Moves some code from -api-v1 to -core. Now -api-v1 doesn't have to access the Page class, fixing an issue where you had to `npm link u-wave-core` into -api-v1 to get it to work.

Later we should also add a `createEntry` function to this new history plugin, so that the history can be entirely handled in core.