### PR TITLE
Switch to bcryptjs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "node": ">= 4.0"
   },
   "dependencies": {
-    "bcrypt": "^1.0.0",
+    "bcryptjs": "^2.4.3",
     "bluebird": "^3.4.6",
     "clamp": "^1.0.1",
     "debug": "^2.6.0",

--- a/src/plugins/users.js
+++ b/src/plugins/users.js
@@ -1,4 +1,4 @@
-import * as bcrypt from 'bcrypt';
+import * as bcrypt from 'bcryptjs';
 
 const debug = require('debug')('uwave:users');
 


### PR DESCRIPTION
Same API as native bcrypt, but not native. Means one less native dependency and faster install etc.

bcryptjs is about 30% slower than native bcrypt but it's only during signup and login and it's fine if those things take a few more ms.