### PR TITLE
deps: speakingurl → transliteration

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "mongoose": "^4.1.6",
     "mongoose-model-decorators": "^0.3.1",
     "object-values": "^1.0.0",
-    "speakingurl": "^13.0.0"
+    "transliteration": "^1.5.3"
   },
   "devDependencies": {
     "babel-eslint": "^7.1.0",

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -1,6 +1,6 @@
 import mongoose from 'mongoose';
 import { createSchema, pre } from 'mongoose-model-decorators';
-import slugify from 'speakingurl';
+import { slugify } from 'transliteration';
 
 import Page from '../Page';
 
@@ -49,7 +49,7 @@ export default function userModel() {
 
       @pre('validate')
       makeSlug() {
-        this.slug = slugify(this.username, { lang: this.language });
+        this.slug = slugify(this.username);
       }
 
       getPermissions(): Promise<Array<string>> {


### PR DESCRIPTION
The `transliteration` module supports a lot of languages and does things like

`transliteration.slugify('오닉스') // → 'onigseu'` instead of `speakingurl('오닉스') // → ''`

it also *doesn't* do some other things, like

`transliteration.slugify('∞') // → ''` instead of `speakingurl('∞') // → 'infinity'`

so i'm not sure if it's the best thing to do.

Maybe we could also see if speakingurl can just pass through some characters so that we get `speakingurl('오닉스') // → '오닉스'`