### PR TITLE
Show a more useful error message when the User slug is empty, fixes #88

### DIFF
--- a/src/models/User.js
+++ b/src/models/User.js
@@ -38,7 +38,7 @@ export default function userModel() {
         slug: {
           type: String,
           unique: true,
-          required: true,
+          required: [true, 'Usernames must not consist of punctuation only.'],
           index: true
         },
         level: { type: Number, min: 0, max: 9001, default: 0 },


### PR DESCRIPTION
![Like this](http://i.imgur.com/NberNb3.png)