### PR TITLE
chat: Implement message tags. Closes #57

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "debug": "^2.6.0",
     "escape-string-regexp": "^1.0.5",
     "ioredis": "^2.4.0",
+    "is-empty-object": "^1.1.1",
     "lodash": "^4.16.3",
     "mongoose": "^4.1.6",
     "mongoose-model-decorators": "^0.3.1",


### PR DESCRIPTION
This implements a message `tags` object. Clients can send an object with string keys along with a chat message. Users can only use tags if they have the related `chat.tags.$TAG` role. This way, a moderator could use a special tag for announcement messages, for example, while a normal user would not be able to use that tag.

Tag values can be any JSON object.

Ref https://github.com/u-wave/web/issues/374