### PR TITLE
build: Ensure `Promise` always refers to bluebird.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,7 @@
 {
   "presets": ["es2015-node4", "stage-2"],
   "plugins": [
+    "transform-promise-to-bluebird",
     "transform-decorators-legacy",
     "transform-class-properties",
     ["transform-es2015-classes", { "loose": true }],

--- a/package-lock.json
+++ b/package-lock.json
@@ -463,6 +463,12 @@
       "integrity": "sha1-h11ryb52HFiirj/u5dxIldjH+SE=",
       "dev": true
     },
+    "babel-plugin-transform-promise-to-bluebird": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-promise-to-bluebird/-/babel-plugin-transform-promise-to-bluebird-1.1.1.tgz",
+      "integrity": "sha1-27CIIIa6Pabh38LutY0Sk6z+6PY=",
+      "dev": true
+    },
     "babel-plugin-transform-strict-mode": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "babel-plugin-transform-es2015-classes": "^6.8.0",
     "babel-plugin-transform-export-extensions": "^6.5.0",
     "babel-plugin-transform-flow-comments": "^6.5.0",
+    "babel-plugin-transform-promise-to-bluebird": "^1.1.1",
     "babel-preset-es2015-node4": "^2.0.3",
     "babel-preset-stage-2": "^6.5.0",
     "babel-register": "^6.5.2",

--- a/src/Uwave.js
+++ b/src/Uwave.js
@@ -1,6 +1,5 @@
 import EventEmitter from 'events';
 import mongoose, { Connection as MongooseConnection } from 'mongoose';
-import Promise from 'bluebird';
 import Redis from 'ioredis';
 import debug from 'debug';
 import values from 'object-values';

--- a/src/plugins/booth.js
+++ b/src/plugins/booth.js
@@ -1,4 +1,3 @@
-import Promise from 'bluebird';
 import { Types as MongoTypes } from 'mongoose';
 
 const debug = require('debug')('uwave:advance');


### PR DESCRIPTION
So we're always returning the right type of Promise from functions.