### PR TITLE
Implement locking during booth advances.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5027,6 +5027,14 @@
       "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
       "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
     },
+    "redlock": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redlock/-/redlock-3.0.0.tgz",
+      "integrity": "sha1-AdXZnuWhnFRVfZhNZWwaHdzODo4=",
+      "requires": {
+        "bluebird": "3.5.0"
+      }
+    },
     "regenerate": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "lodash": "^4.16.3",
     "mongoose": "^4.1.6",
     "mongoose-model-decorators": "^0.3.1",
+    "ms": "^2.0.0",
     "object-values": "^1.0.0",
+    "redlock": "^3.0.0",
     "transliteration": "^1.6.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Prevents some issues when the booth advances very quickly (eg. when a song is 0 seconds long), especially an issue where the booth would advance while the waitlist was still cycling and the same user could end up in the waitlist twice.