### PR TITLE
sources: Add optional `user` parameter to media sources.

### DIFF
--- a/src/sources/ImportContext.js
+++ b/src/sources/ImportContext.js
@@ -1,3 +1,5 @@
+import SourceContext from './SourceContext';
+
 /**
  * Wrapper around playlist functions for use with import plugins. Intended to be
  * temporary until more data manipulation stuff is moved into core from api-v1.
@@ -5,13 +7,7 @@
  * This is legacy, media sources should use the methods provided by the
  * `playlists` plugin instead.
  */
-export default class ImportContext {
-  constructor(uw, source, user) {
-    this.uw = uw;
-    this.source = source;
-    this.user = user;
-  }
-
+export default class ImportContext extends SourceContext {
   /**
    * Create a playlist for the current user.
    *

--- a/src/sources/SourceContext.js
+++ b/src/sources/SourceContext.js
@@ -1,0 +1,7 @@
+export default class SourceContext {
+  constructor(uw, source, user) {
+    this.uw = uw;
+    this.source = source;
+    this.user = user;
+  }
+}

--- a/test/sources.js
+++ b/test/sources.js
@@ -43,14 +43,14 @@ describe('Media Sources', () => {
   it('should respond to search(query) API calls', () => {
     server.source('test-source', testSource);
     const query = 'search-query';
-    return expect(server.source('test-source').search(query)).to.eventually.eql([
+    return expect(server.source('test-source').search(null, query)).to.eventually.eql([
       { sourceType: 'test-source', sourceID: query }
     ]);
   });
 
   it('should respond to get(ids) API calls', () => {
     server.source('test-source', testSource);
-    return expect(server.source('test-source').get(['one', 'two'])).to.eventually.eql([
+    return expect(server.source('test-source').get(null, ['one', 'two'])).to.eventually.eql([
       { sourceType: 'test-source', sourceID: 'one' },
       { sourceType: 'test-source', sourceID: 'two' }
     ]);
@@ -69,7 +69,7 @@ describe('Media Sources', () => {
 
     expect(getCalled).to.equal(false);
 
-    const promise = server.source('test-source').getOne(id);
+    const promise = server.source('test-source').getOne(null, id);
 
     expect(getCalled).to.equal(true);
 


### PR DESCRIPTION
Sources can now receive a `context` parameter on the Search and Get
actions, in addition to Import actions. Sources can opt in by setting
their `api` property to 2, so sources that don't need it will still work.

The `context` parameter is an object that currently has `uw`, `source`
and `user` properties.

This is useful for playlists search, primarily.