### PR TITLE
Use IORedis#quit instead of IORedis#end

### DIFF
--- a/src/Uwave.js
+++ b/src/Uwave.js
@@ -283,7 +283,7 @@ export default class UWaveServer extends EventEmitter {
     this.log('stopping üWave...');
 
     await Promise.all([
-      this.redis.end(),
+      this.redis.quit(),
       this.mongo.close()
     ]);
 


### PR DESCRIPTION
`.end` is deprecated. `.quit` waits until pending messages are sent
before disconnecting.