### PR TITLE
playlists: faster getPlaylistItems with a single query

### DIFF
--- a/src/models/PlaylistItem.js
+++ b/src/models/PlaylistItem.js
@@ -5,7 +5,12 @@ const { Types } = mongoose.Schema;
 
 export default function playlistItemModel() {
   const schema = new Schema({
-    media: { type: Types.ObjectId, ref: 'Media', required: true },
+    media: {
+      type: Types.ObjectId,
+      ref: 'Media',
+      required: true,
+      index: true,
+    },
     artist: {
       type: String,
       max: 128,

--- a/src/plugins/playlists.js
+++ b/src/plugins/playlists.js
@@ -155,7 +155,7 @@ export class PlaylistsRepository {
       },
       { $project: { _id: 0, items: 1 } },
       { $unwind: '$items' },
-      { $replaceWith: '$items' },
+      { $replaceRoot: { newRoot: '$items' } },
     ];
 
     if (filter) {

--- a/src/plugins/playlists.js
+++ b/src/plugins/playlists.js
@@ -119,27 +119,6 @@ export class PlaylistsRepository {
     return {};
   }
 
-  async getPlaylistItemIDsFiltered(playlist, filter) {
-    const PlaylistItem = this.uw.model('PlaylistItem');
-    const rx = new RegExp(escapeStringRegExp(filter), 'i');
-    const matches = await PlaylistItem.where({
-      _id: { $in: playlist.media },
-      $or: [{ artist: rx }, { title: rx }],
-    }).select('_id');
-
-    const allItemIDs = matches.map((item) => item.id);
-
-    // We want this sorted by the original playlist item order, so we can
-    // just walk through the original playlist and only keep the items that we
-    // need.
-    return playlist.media.filter((id) => allItemIDs.indexOf(`${id}`) !== -1);
-  }
-
-  // eslint-disable-next-line class-methods-use-this
-  async getPlaylistItemIDsUnfiltered(playlist) {
-    return playlist.media;
-  }
-
   async getPlaylistItem(itemID) {
     const PlaylistItem = this.uw.model('PlaylistItem');
 
@@ -162,29 +141,69 @@ export class PlaylistsRepository {
   }
 
   async getPlaylistItems(playlistOrID, filter = null, pagination = null) {
-    const PlaylistItem = this.uw.model('PlaylistItem');
     const playlist = await this.getPlaylist(playlistOrID);
-    const filteredItemIDs = filter
-      ? await this.getPlaylistItemIDsFiltered(playlist, filter)
-      : await this.getPlaylistItemIDsUnfiltered(playlist);
 
-    let itemIDs = filteredItemIDs;
-    if (pagination) {
-      const start = pagination.offset;
-      const end = start + pagination.limit;
-      itemIDs = itemIDs.slice(start, end);
+    const aggregate = [
+      // find the playlist
+      { $match: { _id: playlist._id } },
+      { $limit: 1 },
+      // find the items
+      {
+        $lookup: {
+          from: 'playlistitems', localField: 'media', foreignField: '_id', as: 'items',
+        },
+      },
+      { $project: { _id: 0, items: 1 } },
+      { $unwind: '$items' },
+      { $replaceWith: '$items' },
+    ];
+
+    if (filter) {
+      const rx = new RegExp(escapeStringRegExp(filter), 'i');
+      aggregate.push({
+        $match: {
+          $or: [{ artist: rx }, { title: rx }],
+        },
+      });
     }
-    const items = itemIDs.length > 0
-      ? await PlaylistItem.find()
-        .where('_id').in(itemIDs)
-        .populate('media')
-      : [];
 
-    const results = itemIDs.map((itemID) => items.find((item) => `${item.id}` === `${itemID}`));
+    const aggregateCount = [
+      { $count: 'filtered' },
+    ];
+    const aggregateItems = [];
 
-    return new Page(results, {
+    if (pagination) {
+      aggregateItems.push(
+        { $skip: pagination.offset },
+        { $limit: pagination.limit },
+      );
+    }
+
+    // look up the media items after this is all filtered down
+    aggregateItems.push(
+      {
+        $lookup: {
+          from: 'media', localField: 'media', foreignField: '_id', as: 'media',
+        },
+      },
+      { $unwind: '$media' }, // is always 1 item, is there a better way than $unwind?
+    );
+
+    aggregate.push({
+      $facet: {
+        count: aggregateCount,
+        items: aggregateItems,
+      },
+    });
+
+    const [{ count, items }] = await this.uw.model('Playlist').aggregate(aggregate);
+
+    // `items` is the same shape as a PlaylistItem instance!
+
+    return new Page(items, {
       pageSize: pagination ? pagination.limit : null,
-      filtered: filteredItemIDs.length,
+      // `count` can be the empty array if the playlist has no items
+      filtered: count.length === 1 ? count[0].filtered : playlist.media.length,
       total: playlist.media.length,
 
       current: pagination,


### PR DESCRIPTION
Using a `$lookup` pipeline to search for playlist items in a playlist, doing filtering and pagination in MongoDB, and doing another `$lookup` for the base media data. Now everything is done in MongoDB instead of doing like 3 roundtrips to execute part of the query in MongoDB, part in JS, back and forth etc.

Raises the minimum supported MongoDB version to 3.4 or something which is already almost 3 years old, so I think that's ok :woman_shrugging: 