### PR TITLE
Respect playlist item order in `getPlaylistItems`

### DIFF
--- a/src/plugins/playlists.js
+++ b/src/plugins/playlists.js
@@ -148,14 +148,16 @@ class PlaylistsRepository {
       { $match: { _id: playlist._id } },
       { $limit: 1 },
       // find the items
+      { $project: { _id: 0, media: 1 } },
+      { $unwind: '$media' },
       {
         $lookup: {
-          from: 'playlistitems', localField: 'media', foreignField: '_id', as: 'items',
+          from: 'playlistitems', localField: 'media', foreignField: '_id', as: 'item',
         },
       },
-      { $project: { _id: 0, items: 1 } },
-      { $unwind: '$items' },
-      { $replaceRoot: { newRoot: '$items' } },
+      // return only the items
+      { $unwind: '$item' }, // just one each
+      { $replaceRoot: { newRoot: '$item' } },
     ];
 
     if (filter) {


### PR DESCRIPTION
This pretty important feature was accidentally broken in #351.

It would do the playlist items lookup in one go for the entire playlist,
but then order is not guaranteed. This changes it to do the lookup for
individual playlist items. Hopefully it doesn't tank performance too
much :)