### PR TITLE
Unconditionally add social authentication routes.

### DIFF
--- a/src/routes/authenticate.js
+++ b/src/routes/authenticate.js
@@ -60,23 +60,19 @@ function authenticateRoutes(api, options) {
     .delete(
       '/session/:id',
       route(controller.removeSession),
+    )
+    // GET /auth/service/google - Initiate a social login using Google.
+    .get(
+      '/service/google',
+      passport.authenticate('google'),
+      route(controller.login.bind(null, options)),
+    )
+    // GET /auth/service/google/callback - Finish a social login using Google.
+    .get(
+      '/service/google/callback',
+      passport.authenticate('google'),
+      route(controller.socialLoginCallback.bind(null, options)),
     );
-
-  if (passport.supports('google')) {
-    auth
-      // GET /auth/service/google - Initiate a social login using Google.
-      .get(
-        '/service/google',
-        passport.authenticate('google'),
-        route(controller.login.bind(null, options)),
-      )
-      // GET /auth/service/google/callback - Finish a social login using Google.
-      .get(
-        '/service/google/callback',
-        passport.authenticate('google'),
-        route(controller.socialLoginCallback.bind(null, options)),
-      );
-  }
 
   return auth;
 }


### PR DESCRIPTION
Passport will not try to use the strategy until a request comes in, and
fail gracefully if it does.

Combined with #380, this clears a future path towards runtime addition/
removal of authentication strategies.