### PR TITLE
Add configurable CORS settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "body-parser": "^1.19.0",
     "cookie": "^0.4.0",
     "cookie-parser": "^1.4.4",
+    "cors": "^2.8.5",
     "debug": "^4.1.1",
     "escape-string-regexp": "^4.0.0",
     "explain-error": "^1.0.4",

--- a/src/HttpApi.js
+++ b/src/HttpApi.js
@@ -65,7 +65,11 @@ class UwaveHttpApi extends Router {
       secret: options.secret,
     });
 
-    uw.express.use(helmet());
+    uw.express.use(helmet({
+      referrerPolicy: {
+        policy: ['origin-when-cross-origin'],
+      },
+    }));
 
     const corsOptions = {
       origin(origin, callback) {

--- a/src/HttpApi.js
+++ b/src/HttpApi.js
@@ -26,6 +26,7 @@ const errorHandler = require('./middleware/errorHandler');
 
 // utils
 const AuthRegistry = require('./AuthRegistry');
+const matchOrigin = require('./utils/matchOrigin');
 
 const optionsSchema = require('./schemas/httpApi.json');
 
@@ -68,12 +69,7 @@ class UwaveHttpApi extends Router {
 
     const corsOptions = {
       origin(origin, callback) {
-        const { allowedOrigins } = runtimeOptions;
-        if (allowedOrigins.includes(origin) || allowedOrigins.includes('*')) {
-          callback(null, true);
-        } else {
-          callback(new Error('Origin not allowed'));
-        }
+        callback(null, matchOrigin(origin, runtimeOptions.allowedOrigins));
       },
     };
     uw.express.options('/api/*', cors(corsOptions));

--- a/src/HttpApi.js
+++ b/src/HttpApi.js
@@ -4,6 +4,7 @@ const Router = require('router');
 const express = require('express');
 const bodyParser = require('body-parser');
 const cookieParser = require('cookie-parser');
+const cors = require('cors');
 const helmet = require('helmet');
 const http = require('http');
 const debug = require('debug')('uwave:http-api');
@@ -26,6 +27,8 @@ const errorHandler = require('./middleware/errorHandler');
 // utils
 const AuthRegistry = require('./AuthRegistry');
 
+const optionsSchema = require('./schemas/httpApi.json');
+
 function defaultCreatePasswordResetEmail({ token, requestUrl }) {
   const parsed = new URL(requestUrl);
   const { hostname } = parsed;
@@ -44,7 +47,16 @@ function defaultCreatePasswordResetEmail({ token, requestUrl }) {
 
 class UwaveHttpApi extends Router {
   static async plugin(uw, options) {
-    debug('setup');
+    uw.config.register(optionsSchema['uw:key'], optionsSchema);
+
+    let runtimeOptions = await uw.config.get(optionsSchema['uw:key']);
+    uw.config.on('set', (key, value) => {
+      if (key === 'u-wave:api') {
+        runtimeOptions = value;
+      }
+    });
+
+    debug('setup', runtimeOptions);
     uw.express = express();
     uw.server = http.createServer(uw.express);
 
@@ -53,9 +65,21 @@ class UwaveHttpApi extends Router {
     });
 
     uw.express.use(helmet());
-    uw.express.use('/api', uw.httpApi);
+
+    const corsOptions = {
+      origin(origin, callback) {
+        const { allowedOrigins } = runtimeOptions;
+        if (allowedOrigins.includes(origin) || allowedOrigins.includes('*')) {
+          callback(null, true);
+        } else {
+          callback(new Error('Origin not allowed'));
+        }
+      },
+    };
+    uw.express.options('/api/*', cors(corsOptions));
+    uw.express.use('/api', cors(corsOptions), uw.httpApi);
     // An older name
-    uw.express.use('/v1', uw.httpApi);
+    uw.express.use('/v1', cors(corsOptions), uw.httpApi);
 
     // Set up error handlers after all the plugins have registered their routes.
     uw.after(async () => {

--- a/src/schemas/httpApi.json
+++ b/src/schemas/httpApi.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://ns.u-wave.net/config/api.json#",
+  "uw:key": "u-wave:httpApi",
+  "uw:access": "admin",
+  "type": "object",
+  "title": "HTTP API Settings",
+  "description": "Configure the üWave HTTP API for this instance.",
+  "properties": {
+    "allowedOrigins": {
+      "title": "Allowed CORS Origins",
+      "description": "The URLs that are allowed to access the HTTP API. Note this *only* applies to web browsers: non-web clients can always access the HTTP API.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "format": "url"
+      },
+      "default": ["*"]
+    }
+  },
+  "required": ["allowedOrigins"]
+}
+

--- a/src/schemas/httpApi.json
+++ b/src/schemas/httpApi.json
@@ -15,7 +15,7 @@
         "type": "string",
         "format": "url"
       },
-      "default": ["*"]
+      "default": []
     }
   },
   "required": ["allowedOrigins"]

--- a/src/utils/matchOrigin.js
+++ b/src/utils/matchOrigin.js
@@ -19,7 +19,7 @@ const getAllowedOriginsRegExp = memoize((allowedOrigins) => {
     return escapeRegExp(origin).replace('\\*', () => '.+?');
   }
 
-  return new RegExp(`^(?:${allowedOrigins.map(singleOriginToRegExp)})$`);
+  return new RegExp(`^(?:${allowedOrigins.map(singleOriginToRegExp).join('|')})$`);
 });
 
 function matchOrigin(origin, allowedOrigins) {

--- a/src/utils/matchOrigin.js
+++ b/src/utils/matchOrigin.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const { escapeRegExp } = require('lodash');
+
+function memoize(fn) {
+  let lastArg;
+  let lastReturn;
+  return (arg) => {
+    if (arg !== lastArg) {
+      lastArg = arg;
+      lastReturn = fn(arg);
+    }
+    return lastReturn;
+  };
+}
+
+const getAllowedOriginsRegExp = memoize((allowedOrigins) => {
+  function singleOriginToRegExp(origin) {
+    return escapeRegExp(origin).replace('\\*', () => '.+?');
+  }
+
+  return new RegExp(`^(?:${allowedOrigins.map(singleOriginToRegExp)})$`);
+});
+
+function matchOrigin(origin, allowedOrigins) {
+  if (allowedOrigins.length === 0) {
+    return false;
+  }
+
+  return getAllowedOriginsRegExp(allowedOrigins).test(origin);
+}
+
+module.exports = matchOrigin;


### PR DESCRIPTION
By default, the API rejects cross-origin requests. This PR introduces runtime configuration to add allowed origins. This is mostly intended for use by the demo server which has to support `*-u-wave-web.netlify.app` for the web client deploy previews, but could also be used by other servers with staging environments or a separate API domain.