### PR TITLE
Allow `sourceID` to be number when adding media

### DIFF
--- a/src/validations.js
+++ b/src/validations.js
@@ -336,7 +336,7 @@ exports.addPlaylistItems = {
           type: 'object',
           properties: {
             sourceType: { type: 'string' },
-            sourceID: { type: 'string' },
+            sourceID: { type: ['string', 'number'] },
             artist: { type: 'string' },
             title: { type: 'string' },
           },


### PR DESCRIPTION
The SoundCloud media source uses numeric IDs.