### PR TITLE
Add HTTP API tests for ACL routes

### DIFF
--- a/src/HttpApi.js
+++ b/src/HttpApi.js
@@ -11,7 +11,6 @@ const debug = require('debug')('uwave:http-api');
 
 // routes
 const authenticate = require('./routes/authenticate');
-const acl = require('./routes/acl');
 const bans = require('./routes/bans');
 const search = require('./routes/search');
 const server = require('./routes/server');

--- a/src/HttpApi.js
+++ b/src/HttpApi.js
@@ -11,6 +11,7 @@ const debug = require('debug')('uwave:http-api');
 
 // routes
 const authenticate = require('./routes/authenticate');
+const acl = require('./routes/acl');
 const bans = require('./routes/bans');
 const search = require('./routes/search');
 const server = require('./routes/server');

--- a/src/controllers/acl.js
+++ b/src/controllers/acl.js
@@ -25,7 +25,7 @@ async function createRole(req, res) {
   });
 }
 
-async function deleteRole(req, res) {
+async function deleteRole(req) {
   const { name } = req.params;
   const { acl } = req.uwave;
 

--- a/src/controllers/acl.js
+++ b/src/controllers/acl.js
@@ -12,19 +12,20 @@ async function list(req) {
   });
 }
 
-async function createRole(req) {
+async function createRole(req, res) {
   const { name } = req.params;
   const { permissions } = req.body;
   const { acl } = req.uwave;
 
   const role = await acl.createRole(name, permissions);
 
+  res.status(201);
   return toItemResponse(role, {
     url: req.fullUrl,
   });
 }
 
-async function deleteRole(req) {
+async function deleteRole(req, res) {
   const { name } = req.params;
   const { acl } = req.uwave;
 

--- a/src/plugins/acl.js
+++ b/src/plugins/acl.js
@@ -88,6 +88,12 @@ class Acl {
       { roles },
       { upsert: true },
     );
+
+    const subRoles = await Promise.all(roles.map(getSubRoles));
+    return {
+      name,
+      permissions: flatten(subRoles).map((role) => role._id),
+    };
   }
 
   async deleteRole(name) {
@@ -145,7 +151,7 @@ class Acl {
 
 async function acl(uw, opts = {}) {
   uw.acl = new Acl(uw);
-  uw.httpApi.use('/acl', routes());
+  uw.httpApi.use('/roles', routes());
 
   if (opts.defaultRoles !== false) {
     uw.after(async () => {

--- a/src/route.js
+++ b/src/route.js
@@ -4,7 +4,7 @@ function route(fn) {
   return (req, res, next) => {
     Promise.resolve(fn(req, res))
       .then((json) => {
-        res.status(200).json(json);
+        res.json(json);
       })
       .catch(next);
   };

--- a/src/routes/acl.js
+++ b/src/routes/acl.js
@@ -7,7 +7,7 @@ const protect = require('../middleware/protect');
 const schema = require('../middleware/schema');
 const controller = require('../controllers/acl');
 
-function serverRoutes() {
+function aclRoutes() {
   return router()
     // GET /roles - List available roles.
     .get(
@@ -30,4 +30,4 @@ function serverRoutes() {
     );
 }
 
-module.exports = serverRoutes;
+module.exports = aclRoutes;

--- a/test/acl.js
+++ b/test/acl.js
@@ -88,7 +88,6 @@ describe('ACL', () => {
     });
 
     it('requires the acl.create role', async () => {
-      const user = await uw.test.createUser();
       const token = await uw.test.createTestSessionToken(user);
 
       await supertest(uw.server)
@@ -111,7 +110,6 @@ describe('ACL', () => {
     });
 
     it('validates input', async () => {
-      const user = await uw.test.createUser();
       const token = await uw.test.createTestSessionToken(user);
       await uw.acl.allow(user, ['acl.create']);
 
@@ -147,7 +145,6 @@ describe('ACL', () => {
     });
 
     it('creates a role', async () => {
-      const user = await uw.test.createUser();
       const token = await uw.test.createTestSessionToken(user);
       await uw.acl.allow(user, ['acl.create']);
 
@@ -176,7 +173,6 @@ describe('ACL', () => {
     });
 
     it('requires the acl.delete role', async () => {
-      const user = await uw.test.createUser();
       const token = await uw.test.createTestSessionToken(user);
 
       await uw.acl.createRole('test.role', ['test.permission', 'test.permission2']);
@@ -195,7 +191,6 @@ describe('ACL', () => {
     });
 
     it('deletes the role', async () => {
-      const user = await uw.test.createUser();
       const moderator = await uw.test.createUser();
       const token = await uw.test.createTestSessionToken(moderator);
 

--- a/test/acl.js
+++ b/test/acl.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const assert = require('assert');
+const supertest = require('supertest');
+const sinon = require('sinon');
 const createUwave = require('./utils/createUwave');
 
 describe('ACL', () => {
@@ -59,5 +61,161 @@ describe('ACL', () => {
     assert(Object.keys(await uw.acl.getAllRoles()).includes('test.role'));
     await uw.acl.deleteRole('test.role');
     assert(!Object.keys(await uw.acl.getAllRoles()).includes('test.role'));
+  });
+
+  describe('GET /roles', () => {
+    it('lists available roles', async () => {
+      await uw.acl.createRole('test.role', ['test.permission', 'test.permission2']);
+
+      const res = await supertest(uw.server)
+        .get('/api/roles')
+        .expect(200);
+
+      sinon.assert.match(res.body.data, {
+        'test.role': ['test.permission', 'test.permission2'],
+      });
+    });
+  });
+
+  describe('PUT /roles/:name', () => {
+    it('requires authentication', async () => {
+      await supertest(uw.server)
+        .put('/api/roles/test.role')
+        .send({
+          permissions: ['test.permission', 'test.permission2'],
+        })
+        .expect(403);
+    });
+
+    it('requires the acl.create role', async () => {
+      const user = await uw.test.createUser();
+      const token = await uw.test.createTestSessionToken(user);
+
+      await supertest(uw.server)
+        .put('/api/roles/test.role')
+        .set('Cookie', `uwsession=${token}`)
+        .send({
+          permissions: ['test.permission', 'test.permission2'],
+        })
+        .expect(403);
+
+      await uw.acl.allow(user, ['acl.create']);
+
+      await supertest(uw.server)
+        .put('/api/roles/test.role')
+        .set('Cookie', `uwsession=${token}`)
+        .send({
+          permissions: ['test.permission', 'test.permission2'],
+        })
+        .expect(201);
+    });
+
+    it('validates input', async () => {
+      const user = await uw.test.createUser();
+      const token = await uw.test.createTestSessionToken(user);
+      await uw.acl.allow(user, ['acl.create']);
+
+      let res = await supertest(uw.server)
+        .put('/api/roles/test.role')
+        .set('Cookie', `uwsession=${token}`)
+        .send({})
+        .expect(400);
+      sinon.assert.match(res.body.errors[0], {
+        status: 400,
+        code: 'validation-error',
+      });
+
+      res = await supertest(uw.server)
+        .put('/api/roles/test.role')
+        .set('Cookie', `uwsession=${token}`)
+        .send({ permissions: 'not an array' })
+        .expect(400);
+      sinon.assert.match(res.body.errors[0], {
+        status: 400,
+        code: 'validation-error',
+      });
+
+      res = await supertest(uw.server)
+        .put('/api/roles/test.role')
+        .set('Cookie', `uwsession=${token}`)
+        .send({ permissions: [{ not: 'a' }, 'string'] })
+        .expect(400);
+      sinon.assert.match(res.body.errors[0], {
+        status: 400,
+        code: 'validation-error',
+      });
+    });
+
+    it('creates a role', async () => {
+      const user = await uw.test.createUser();
+      const token = await uw.test.createTestSessionToken(user);
+      await uw.acl.allow(user, ['acl.create']);
+
+      const res = await supertest(uw.server)
+        .put('/api/roles/test.role')
+        .set('Cookie', `uwsession=${token}`)
+        .send({
+          permissions: ['test.permission', 'test.permission2'],
+        })
+        .expect(201);
+
+      sinon.assert.match(res.body.data, {
+        name: 'test.role',
+        permissions: ['test.permission', 'test.permission2'],
+      });
+    });
+  });
+
+  describe('DELETE /roles/:name', () => {
+    it('requires authentication', async () => {
+      await uw.acl.createRole('test.role', []);
+
+      await supertest(uw.server)
+        .delete('/api/roles/test.role')
+        .expect(403);
+    });
+
+    it('requires the acl.delete role', async () => {
+      const user = await uw.test.createUser();
+      const token = await uw.test.createTestSessionToken(user);
+
+      await uw.acl.createRole('test.role', ['test.permission', 'test.permission2']);
+
+      await supertest(uw.server)
+        .delete('/api/roles/test.role')
+        .set('Cookie', `uwsession=${token}`)
+        .expect(403);
+
+      await uw.acl.allow(user, ['acl.delete']);
+
+      await supertest(uw.server)
+        .delete('/api/roles/test.role')
+        .set('Cookie', `uwsession=${token}`)
+        .expect(200);
+    });
+
+    it('deletes the role', async () => {
+      const user = await uw.test.createUser();
+      const moderator = await uw.test.createUser();
+      const token = await uw.test.createTestSessionToken(moderator);
+
+      await uw.acl.createRole('test.role', ['test.permission', 'test.permission2']);
+      await uw.acl.allow(user, ['test.role']);
+      await uw.acl.allow(moderator, ['acl.delete']);
+
+      assert(await uw.acl.isAllowed(user, 'test.role'));
+
+      await supertest(uw.server)
+        .delete('/api/roles/test.role')
+        .set('Cookie', `uwsession=${token}`)
+        .expect(200);
+
+      const res = await supertest(uw.server)
+        .get('/api/roles')
+        .expect(200);
+      assert(!Object.keys(res.body.data).includes('test.role'));
+
+      assert(!await uw.acl.isAllowed(user, 'test.role'));
+    });
   });
 });


### PR DESCRIPTION
Changes the HTTP status code for success in `PUT /api/roles/rolename` to 201.