### PR TITLE
Use a temporary Redis server for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,4 +42,5 @@ jobs:
       - name: Run tests
         run: npm run test:mocha
         env:
+          REDIS_URL: '127.0.0.1:6379'
           MONGODB_HOST: '127.0.0.1:27017'

--- a/test/utils/createUwave.js
+++ b/test/utils/createUwave.js
@@ -1,20 +1,50 @@
 'use strict';
 
 const getPort = require('get-port');
-const Redis = require('ioredis');
+const { once } = require('events');
+const { spawn } = require('child_process');
 const deleteDatabase = require('./deleteDatabase');
 const uwave = require('../..');
 const testPlugin = require('./plugin');
 
 const DB_HOST = process.env.MONGODB_HOST || 'localhost';
 
+/**
+ * Create an in-memory redis database to run tests against.
+ */
+async function createIsolatedRedis() {
+  const port = await getPort();
+
+  const proc = spawn('redis-server', ['-']);
+  proc.stdin.end(`
+    port ${port}
+    save ""
+  `);
+
+  await once(proc, 'spawn');
+
+  for await (const buf of proc.stdout) {
+    if (buf.toString().includes('Ready to accept connections')) {
+      break;
+    }
+  }
+
+  return {
+    port,
+    proc,
+  };
+}
+
 async function createUwave(name, options) {
+  const redisServer = await createIsolatedRedis();
   const mongoUrl = `mongodb://${DB_HOST}/uw_test_${name}`;
+
   const port = await getPort();
 
   const uw = uwave({
     ...options,
     port,
+    redis: `redis://localhost:${redisServer.port}`,
     mongo: mongoUrl,
     secret: Buffer.from(`secret_${name}`),
   });
@@ -24,10 +54,8 @@ async function createUwave(name, options) {
   uw.destroy = async () => {
     await uw.close();
 
-    // Clear state between test runs.
-    const redis = new Redis('redis://localhost:6379');
-    await redis.flushall();
-    await redis.quit();
+    redisServer.proc.kill('SIGINT');
+    await once(redisServer.proc, 'close');
 
     await deleteDatabase(mongoUrl);
   };

--- a/test/utils/createUwave.js
+++ b/test/utils/createUwave.js
@@ -80,10 +80,12 @@ async function createUwave(name, options) {
   uw.use(testPlugin);
 
   uw.destroy = async () => {
-    await uw.close();
-
-    await redisServer.close();
-    await deleteDatabase(mongoUrl);
+    try {
+      await uw.close();
+    } finally {
+      await redisServer.close();
+      await deleteDatabase(mongoUrl);
+    }
   };
 
   await uw.listen();

--- a/test/utils/createUwave.js
+++ b/test/utils/createUwave.js
@@ -1,8 +1,9 @@
 'use strict';
 
-const getPort = require('get-port');
 const { once } = require('events');
 const { spawn } = require('child_process');
+const getPort = require('get-port');
+const Redis = require('ioredis');
 const deleteDatabase = require('./deleteDatabase');
 const uwave = require('../..');
 const testPlugin = require('./plugin');


### PR DESCRIPTION
This prevents interfering with the "main" server on developer systems.