### PR TITLE
Remove option to disable default roles

### DIFF
--- a/src/plugins/acl.js
+++ b/src/plugins/acl.js
@@ -149,15 +149,13 @@ class Acl {
   }
 }
 
-async function acl(uw, opts = {}) {
+async function acl(uw) {
   uw.acl = new Acl(uw);
   uw.httpApi.use('/roles', routes());
 
-  if (opts.defaultRoles !== false) {
-    uw.after(async () => {
-      await uw.acl.maybeAddDefaultRoles();
-    });
-  }
+  uw.after(async () => {
+    await uw.acl.maybeAddDefaultRoles();
+  });
 }
 
 module.exports = acl;


### PR DESCRIPTION
Most of the roles are important, we could get rid of Special and
one of Moderator/Manager from the default set in the future and
make the remaining ones non-deletable.