### PR TITLE
Add `play()` hook for media sources

### DIFF
--- a/src/Source.js
+++ b/src/Source.js
@@ -24,7 +24,8 @@ const { SourceNoImportError } = require('./errors');
  *   ...args: unknown[]
  * ) => Promise<PlaylistItemDesc[]>} search
  * @prop {(context: ImportContext, ...args: unknown[]) => Promise<unknown>} [import]
- * @prop {(context: SourceContext, entry: PlaylistItemDesc) => Promise<import('type-fest').JsonObject>} [play]
+ * @prop {(context: SourceContext, entry: PlaylistItemDesc) =>
+ *     Promise<import('type-fest').JsonObject>} [play]
  *
  * @typedef {SourcePluginV1 | SourcePluginV2} SourcePlugin
  */

--- a/src/Source.js
+++ b/src/Source.js
@@ -165,6 +165,9 @@ class Source {
   }
 
   /**
+   * Playback hook. Media sources can use this to pass the necessary data for
+   * media playback to clients, for example a temporary signed URL.
+   *
    * @param {User} user
    * @param {PlaylistItemDesc} entry
    */

--- a/src/Source.js
+++ b/src/Source.js
@@ -24,6 +24,7 @@ const { SourceNoImportError } = require('./errors');
  *   ...args: unknown[]
  * ) => Promise<PlaylistItemDesc[]>} search
  * @prop {(context: ImportContext, ...args: unknown[]) => Promise<unknown>} [import]
+ * @prop {(context: SourceContext, entry: PlaylistItemDesc) => Promise<import('type-fest').JsonObject>} [play]
  *
  * @typedef {SourcePluginV1 | SourcePluginV2} SourcePlugin
  */
@@ -160,6 +161,18 @@ class Source {
       results = await this.plugin.search(query, page, ...args);
     }
     return this.addSourceType(results);
+  }
+
+  /**
+   * @param {User} user
+   * @param {PlaylistItemDesc} entry
+   */
+  play(user, entry) {
+    if (this.plugin.api === 2 && this.plugin.play != null) {
+      const context = new SourceContext(this.uw, this, user);
+      return this.plugin.play(context, entry);
+    }
+    return undefined;
   }
 
   /**

--- a/test/sources.mjs
+++ b/test/sources.mjs
@@ -33,6 +33,18 @@ describe('Media Sources', () => {
     };
   }
 
+  const testSourceWithPlayHook = {
+    api: 2,
+    name: 'test-source-with-play',
+    async search() { throw new Error('unimplemented'); },
+    async get() { throw new Error('unimplemented'); },
+    async play(context, media) {
+      return {
+        urn: `${media.sourceType}:${media.sourceID}`,
+      };
+    },
+  };
+
   it('should register sources from objects', () => {
     uw.source(testSourceObject);
     assert(uw.source('test-source') instanceof Source);
@@ -82,6 +94,17 @@ describe('Media Sources', () => {
 
     const results = await promise;
     assert.deepStrictEqual(results, { sourceType: 'test-source', sourceID: id });
+  });
+
+  it('should respond to play(media) API calls', async () => {
+    uw.source(testSourceWithPlayHook);
+    const sourceData = await uw.source('test-source-with-play').play(null, {
+      sourceID: '1234',
+      sourceType: 'test-source-with-play',
+    });
+    assert.deepStrictEqual(sourceData, {
+      urn: 'test-source-with-play:1234',
+    });
   });
 
   describe('GET /search/:source', () => {


### PR DESCRIPTION
Media sources can provide a `play()` function that can return arbitrary JSON data. This JSON data is sent to clients as `sourceData`. This is useful for media sources that require temporary signed URLs to access content.