### PR TITLE
Store playback `sourceData`

### DIFF
--- a/src/controllers/booth.js
+++ b/src/controllers/booth.js
@@ -28,6 +28,8 @@ async function getBoothData(uw) {
   }
 
   await historyEntry.populate('media.media');
+  // @ts-ignore TS2322: We just populated historyEntry.media.media
+  const media = booth.getMediaForPlayback(historyEntry);
 
   const stats = await booth.getCurrentVoteStats();
 
@@ -36,7 +38,7 @@ async function getBoothData(uw) {
     playlistID: `${historyEntry.playlist}`,
     playedAt: historyEntry.playedAt.getTime(),
     userID: `${historyEntry.user}`,
-    media: historyEntry.media,
+    media,
     stats,
   };
 }

--- a/src/models/History.js
+++ b/src/models/History.js
@@ -10,10 +10,21 @@ const listOfUsers = [{ type: Types.ObjectId, ref: 'User' }];
 /**
  * @typedef {object} HistoryMedia
  * @prop {import('mongodb').ObjectId} media
+ *     Reference to the `Media` object that is being played.
  * @prop {string} artist
+ *     Snapshot of the media artist name at the time this entry was played.
  * @prop {string} title
+ *     Snapshot of the media title at the time this entry was played.
  * @prop {number} start
+ *     Time to start playback at.
  * @prop {number} end
+ *     Time to stop playback at.
+ * @prop {HistorySourceData} sourceData
+ *     Arbitrary source-specific data required for media playback.
+ */
+
+/**
+ * @typedef {object} HistorySourceData
  */
 
 /**
@@ -59,6 +70,7 @@ const schema = new Schema({
     },
     start: { type: Number, default: 0 },
     end: { type: Number, default: 0 },
+    sourceData: { type: Object, select: false },
   },
   playedAt: { type: Date, default: () => new Date(), index: true },
   upvotes: listOfUsers,


### PR DESCRIPTION
Now /api/now responds with `sourceData` generated by a media source's
`play()` hook. The results of a `play()` hook call are considered
temporary so it is only included in places where playback is imminent or
ongoing: in `advance` socket events and in the `/api/now` response. In
all other cases it is omitted from history models.

The `getMediaForPlayback` method in the booth plugin is a bit hacky. In
the future we could maybe return `historyEntry.media.sourceData` to
clients and make them responsible for merging the two `sourceData`
objects (with a migration period of a few versions). For now, the hack is
needed, so clients do not need to be updated to account for a new
property.

fixes https://github.com/u-wave/core/issues/484