### PR TITLE
Fix adding media to the start of a playlist

### DIFF
--- a/src/plugins/playlists.js
+++ b/src/plugins/playlists.js
@@ -523,7 +523,7 @@ class PlaylistsRepository {
 
     const newItems = await this.createPlaylistItems(user, items);
     const oldMedia = playlist.media;
-    const insertIndex = after === null ? 0 : oldMedia.findIndex((item) => item.equals(after));
+    const insertIndex = after === null ? -1 : oldMedia.findIndex((item) => item.equals(after));
     playlist.media = [
       ...oldMedia.slice(0, insertIndex + 1),
       ...newItems.map((item) => item._id),

--- a/test/playlists.mjs
+++ b/test/playlists.mjs
@@ -545,6 +545,16 @@ describe('Playlists', () => {
       assert.strictEqual(res.body.data.length, 20, 'returns the newly added items');
       assertItemsAndIncludedMedia(res.body);
 
+      const updatedRes = await supertest(uw.server)
+        .get(`/api/playlists/${playlist.id}/media`)
+        .set('Cookie', `uwsession=${token}`)
+        .expect(200);
+      assert.deepStrictEqual(
+        updatedRes.body.data.slice(0, 20).map((item) => item.artist),
+        firstItems.map((item) => item.artist),
+        'adds the items at the start',
+      );
+
       const secondItems = await generateItems(20);
       const res2 = await supertest(uw.server)
         .post(`/api/playlists/${playlist.id}/media`)
@@ -558,6 +568,16 @@ describe('Playlists', () => {
       });
       assert.strictEqual(res2.body.data.length, 20, 'returns the newly added items');
       assertItemsAndIncludedMedia(res2.body);
+
+      const updatedRes2 = await supertest(uw.server)
+        .get(`/api/playlists/${playlist.id}/media`)
+        .set('Cookie', `uwsession=${token}`)
+        .expect(200);
+      assert.deepStrictEqual(
+        updatedRes2.body.data.slice(0, 20).map((item) => item.artist),
+        secondItems.map((item) => item.artist),
+        'adds the items at the start',
+      );
     });
 
     it('inserts items `after` an existing item', async () => {


### PR DESCRIPTION
When you use ?at=start or ?after=null, items should be prepended, but
they ended up at position 1.