### PR TITLE
Improve `getPlaylistsContainingAnyMedia` performance

### DIFF
--- a/src/controllers/search.js
+++ b/src/controllers/search.js
@@ -56,7 +56,16 @@ async function updateSourceData(uw, updates) {
 }
 
 /**
- * @type {import('../types').AuthenticatedController}
+ * @typedef {object} SearchParams
+ * @prop {string} source
+ *
+ * @typedef {object} SearchQuery
+ * @prop {string} query
+ * @prop {string} [include]
+*/
+
+/**
+ * @type {import('../types').AuthenticatedController<SearchParams, SearchQuery, never>}
  */
 async function search(req) {
   const { user } = req;
@@ -106,7 +115,7 @@ async function search(req) {
   });
 
   // Only include related playlists if requested
-  if (include.split(',').includes('playlists')) {
+  if (typeof include === 'string' && include.split(',').includes('playlists')) {
     const playlistsByMediaID = await uw.playlists.getPlaylistsContainingAnyMedia(
       mediasInSearchResults.map((media) => media._id),
       { author: user._id },

--- a/src/controllers/search.js
+++ b/src/controllers/search.js
@@ -106,12 +106,15 @@ async function search(req) {
   });
 
   // Only include related playlists if requested
-  // Clients should probably not request this until it is faster :)
-  if (include === 'playlists') {
+  if (include.split(',').includes('playlists')) {
     const playlistsByMediaID = await uw.playlists.getPlaylistsContainingAnyMedia(
       mediasInSearchResults.map((media) => media._id),
       { author: user._id },
-    );
+    ).catch((error) => {
+      debug('playlists containing media lookup failed', error);
+      // just omit the related playlists if we timed out or crashed
+      return new Map();
+    });
 
     searchResults.forEach((result) => {
       const media = mediaBySourceID.get(String(result.sourceID));

--- a/src/plugins/playlists.js
+++ b/src/plugins/playlists.js
@@ -362,7 +362,7 @@ class PlaylistsRepository {
       });
     }
 
-    const playlists = await Playlist.aggregate(aggregate);
+    const playlists = await Playlist.aggregate(aggregate, { maxTimeMS: 5_000 });
     return playlists.map((raw) => Playlist.hydrate(raw));
   }
 

--- a/src/validations.js
+++ b/src/validations.js
@@ -473,7 +473,7 @@ exports.search = {
     type: 'object',
     properties: {
       query: { type: 'string' },
-      include: { type: 'string' },
+      include: { type: 'string', nullable: true },
     },
     required: ['query'],
   },


### PR DESCRIPTION
I thought this `$lookup.pipeline` solution worked pretty well, but I
think it doesn't let MongoDB use the indices on the `playlistitems`
collection. Also in the past I did `$project` early because I thought it
would be faster to have less data for the remaining steps of the
pipeline, but it's actually very slow when you still have lots of
documents in it.

So, now this uses the simple `$lookup` syntax that only has to look at
an indexed property in `playlistitems`, and moves `$project` to the end.

This cuts it down to a query that's maybe 200ms on wlk.yt (with a few
hundred thousand playlist items).