### PR TITLE
Fix double-executing query in users endpoint

### DIFF
--- a/src/plugins/users.js
+++ b/src/plugins/users.js
@@ -58,7 +58,7 @@ class UsersRepository {
       query.where(queryFilter);
     }
 
-    const totalPromise = User.estimatedDocumentCount();
+    const totalPromise = User.estimatedDocumentCount().exec();
 
     const [
       users,

--- a/test/users.mjs
+++ b/test/users.mjs
@@ -1,0 +1,38 @@
+import supertest from 'supertest';
+import createUwave from './utils/createUwave.mjs';
+
+describe('Users', () => {
+  let user;
+  let uw;
+  beforeEach(async () => {
+    uw = await createUwave('bans');
+    user = await uw.test.createUser();
+  });
+  afterEach(async () => {
+    await uw.destroy();
+  });
+
+  describe('GET /api/users', () => {
+    it('requires authentication', async () => {
+      await supertest(uw.server)
+        .get('/api/users')
+        .expect(401);
+    });
+
+    it('requires the users.list role', async () => {
+      const token = await uw.test.createTestSessionToken(user);
+
+      await supertest(uw.server)
+        .get('/api/users')
+        .set('Cookie', `uwsession=${token}`)
+        .expect(403);
+
+      await uw.acl.allow(user, ['users.list']);
+
+      await supertest(uw.server)
+        .get('/api/users')
+        .set('Cookie', `uwsession=${token}`)
+        .expect(200);
+    });
+  });
+});


### PR DESCRIPTION
passing `totalPromise` twice to `Promise.all` causes it to execute twice because it is a Query, not a Promise. Executing a Query twice is not allowed by mongo(ose). now we start executing it once and can use the resulting Promise twice.

the test doesn't really do much but at least it will catch obvious crashes in the future.