### PR TITLE
Use UUIDs for chat messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "cookie": "^0.5.0",
     "cookie-parser": "^1.4.4",
     "cors": "^2.8.5",
+    "crypto-randomuuid": "^1.0.0",
     "debug": "^4.1.1",
     "escape-string-regexp": "^4.0.0",
     "explain-error": "^1.0.4",

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -1,0 +1,23 @@
+// Contains typings for dependencies that do not have types.
+
+declare module 'crypto-randomuuid' {
+  // From https://github.com/DefinitelyTyped/DefinitelyTyped/blob/04843fe4de7d03161bf6e5f2b51c49b2cd21e96c/types/node/crypto.d.ts#L3019-L3035
+
+  interface RandomUUIDOptions {
+      /**
+       * By default, to improve performance,
+       * Node.js will pre-emptively generate and persistently cache enough
+       * random data to generate up to 128 random UUIDs. To generate a UUID
+       * without using the cache, set `disableEntropyCache` to `true`.
+       *
+       * @default `false`
+       */
+      disableEntropyCache?: boolean | undefined;
+  }
+  /**
+   * Generates a random [RFC 4122](https://www.rfc-editor.org/rfc/rfc4122.txt) version 4 UUID. The UUID is generated using a
+   * cryptographic pseudorandom number generator.
+   */
+  function randomUUID(options?: RandomUUIDOptions): string;
+  export = randomUUID;
+}

--- a/src/plugins/chat.js
+++ b/src/plugins/chat.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const randomUUID = require('crypto-randomuuid');
 const routes = require('../routes/chat');
 
 /**
@@ -16,8 +17,6 @@ const defaultOptions = {
 
 class Chat {
   #uw;
-
-  #chatID = Date.now();
 
   /** @type {ChatOptions} */
   #options;
@@ -95,10 +94,8 @@ class Chat {
       return;
     }
 
-    this.#chatID += 1;
-
     this.#uw.publish('chat:message', {
-      id: `${user.id}-${this.#chatID}`,
+      id: randomUUID(),
       userID: user.id,
       message: this.truncate(message),
       timestamp: Date.now(),


### PR DESCRIPTION
smol tweak to rely less on a global counter. the client has always treated chat IDs as opaque so this shouldn't risk breaking anything.