### PR TITLE
Make `artist`, `title` optional when adding playlist items

### DIFF
--- a/src/plugins/playlists.js
+++ b/src/plugins/playlists.js
@@ -29,8 +29,8 @@ const routes = require('../routes/playlists');
  * @typedef {object} PlaylistItemDesc
  * @prop {string} sourceType
  * @prop {string|number} sourceID
- * @prop {string} artist
- * @prop {string} title
+ * @prop {string} [artist]
+ * @prop {string} [title]
  * @prop {number} [start]
  * @prop {number} [end]
  */

--- a/src/validations.js
+++ b/src/validations.js
@@ -348,7 +348,7 @@ exports.addPlaylistItems = /** @type {const} */ ({
             artist: { type: 'string' },
             title: { type: 'string' },
           },
-          required: ['sourceType', 'sourceID', 'artist', 'title'],
+          required: ['sourceType', 'sourceID'],
         },
       },
     },


### PR DESCRIPTION
If not given, üWave will use defaults from the media source.

This is important for https://github.com/u-wave/web/issues/1855. Media
sources will respond with original titles in search and import requests.
When dragging those media into a playlist from search results, the
client will not send an artist and title field, and üWave will request
them from the media source again, but this time it will respond with
derived data.