### PR TITLE
Handle errors in pre-play hook

### DIFF
--- a/src/plugins/booth.js
+++ b/src/plugins/booth.js
@@ -313,8 +313,13 @@ class Booth {
     const source = this.#uw.source(sourceType);
     if (source) {
       this.#logger.trace({ sourceType: source.type, sourceID }, 'running pre-play hook');
-      const sourceData = await source.play(entry.user, entry.media.media);
-      this.#logger.trace({ sourceType: source.type, sourceID, sourceData }, 'pre-play hook result');
+      let sourceData;
+      try {
+        sourceData = await source.play(entry.user, entry.media.media);
+        this.#logger.trace({ sourceType: source.type, sourceID, sourceData }, 'pre-play hook result');
+      } catch (error) {
+        this.#logger.error({ sourceType: source.type, sourceID, err: error }, 'pre-play hook failed');
+      }
       return sourceData;
     }
 

--- a/src/plugins/booth.js
+++ b/src/plugins/booth.js
@@ -7,6 +7,7 @@ const { EmptyPlaylistError, PlaylistItemNotFoundError } = require('../errors');
 const routes = require('../routes/booth');
 
 /**
+ * @typedef {import('type-fest').JsonObject} JsonObject
  * @typedef {import('../models').User} User
  * @typedef {import('../models').Playlist} Playlist
  * @typedef {import('../models').PlaylistItem} PlaylistItem
@@ -313,6 +314,7 @@ class Booth {
     const source = this.#uw.source(sourceType);
     if (source) {
       this.#logger.trace({ sourceType: source.type, sourceID }, 'running pre-play hook');
+      /** @type {JsonObject | undefined} */
       let sourceData;
       try {
         sourceData = await source.play(entry.user, entry.media.media);


### PR DESCRIPTION
An error in a source pre-play hook could cause the entire process to crash. Now we log the error but keep going as if the hook didn't exist.