### PR TITLE
Add twitch emotes integration

### DIFF
--- a/bin/u-wave-core
+++ b/bin/u-wave-core
@@ -7,6 +7,7 @@ const addFormats = require('ajv-formats').default;
 const ytSource = require('u-wave-source-youtube');
 const scSource = require('u-wave-source-soundcloud');
 const announce = require('u-wave-announce');
+const emotes = require('../src/plugins/emotes');
 const uwave = require('..');
 const pkg = require('../package.json');
 const argv = require('minimist')(process.argv.slice(2));
@@ -48,6 +49,9 @@ const envSchema = {
     },
     YOUTUBE_API_KEY: {
       type: 'string',
+    },
+    EXPERIMENTAL_EMOTES: {
+      type: 'boolean',
     },
   },
 };
@@ -110,6 +114,11 @@ uw.on('redisError', (err) => {
 });
 
 uw.use(announce);
+
+if (config.EXPERIMENTAL_EMOTES) {
+  console.warn('Using experimental third-party emotes integration');
+  uw.use(emotes);
+}
 
 if (config.YOUTUBE_API_KEY) {
   uw.source(ytSource,  {

--- a/dev/u-wave-dev-server
+++ b/dev/u-wave-dev-server
@@ -50,6 +50,9 @@ async function start() {
     timeout: 10,
   });
 
+  const emotes = require('../src/plugins/emotes');
+  uw.use(emotes);
+
   uw.use(async function configureExpress(uw) {
     uw.express.set('json spaces', 2);
   });

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "node": ">= 14.17.0"
   },
   "dependencies": {
+    "@twurple/api": "^6.0.6",
+    "@twurple/auth": "^6.0.6",
     "ajv": "^8.0.5",
     "ajv-formats": "^2.0.2",
     "avvio": "^8.0.0",

--- a/src/HttpApi.js
+++ b/src/HttpApi.js
@@ -12,6 +12,7 @@ const pinoHttp = require('pino-http').default;
 // routes
 const authenticate = require('./routes/authenticate');
 const bans = require('./routes/bans');
+const emotes = require('./routes/emotes');
 const search = require('./routes/search');
 const server = require('./routes/server');
 const users = require('./routes/users');
@@ -123,6 +124,7 @@ async function httpApi(uw, options) {
         options.createPasswordResetEmail ?? defaultCreatePasswordResetEmail,
     }))
     .use('/bans', bans())
+    .use('/emotes', emotes())
     .use('/import', imports())
     .use('/now', now())
     .use('/search', search())

--- a/src/HttpApi.js
+++ b/src/HttpApi.js
@@ -12,7 +12,6 @@ const pinoHttp = require('pino-http').default;
 // routes
 const authenticate = require('./routes/authenticate');
 const bans = require('./routes/bans');
-const emotes = require('./routes/emotes');
 const search = require('./routes/search');
 const server = require('./routes/server');
 const users = require('./routes/users');
@@ -124,7 +123,6 @@ async function httpApi(uw, options) {
         options.createPasswordResetEmail ?? defaultCreatePasswordResetEmail,
     }))
     .use('/bans', bans())
-    .use('/emotes', emotes())
     .use('/import', imports())
     .use('/now', now())
     .use('/search', search())

--- a/src/SocketServer.js
+++ b/src/SocketServer.js
@@ -428,6 +428,10 @@ class SocketServer {
           }
         });
       },
+
+      'emotes:reload': () => {
+        this.broadcast('reloadEmotes', null);
+      },
     };
   }
 

--- a/src/Uwave.js
+++ b/src/Uwave.js
@@ -16,6 +16,7 @@ const models = require('./models');
 const configStore = require('./plugins/configStore');
 const booth = require('./plugins/booth');
 const chat = require('./plugins/chat');
+const emotes = require('./plugins/emotes');
 const motd = require('./plugins/motd');
 const playlists = require('./plugins/playlists');
 const users = require('./plugins/users');
@@ -82,6 +83,10 @@ class UwaveServer extends EventEmitter {
   /** @type {import('./plugins/configStore').ConfigStore} */
   // @ts-expect-error TS2564 Definitely assigned in a plugin
   config;
+
+  /** @type {import('./plugins/emotes').Emotes} */
+  // @ts-expect-error TS2564 Definitely assigned in a plugin
+  emotes;
 
   /** @type {import('./plugins/history').HistoryRepository} */
   // @ts-expect-error TS2564 Definitely assigned in a plugin
@@ -192,6 +197,7 @@ class UwaveServer extends EventEmitter {
 
     boot.use(acl);
     boot.use(chat);
+    boot.use(emotes);
     boot.use(motd);
     boot.use(playlists);
     boot.use(users);

--- a/src/Uwave.js
+++ b/src/Uwave.js
@@ -16,7 +16,6 @@ const models = require('./models');
 const configStore = require('./plugins/configStore');
 const booth = require('./plugins/booth');
 const chat = require('./plugins/chat');
-const emotes = require('./plugins/emotes');
 const motd = require('./plugins/motd');
 const playlists = require('./plugins/playlists');
 const users = require('./plugins/users');
@@ -84,9 +83,8 @@ class UwaveServer extends EventEmitter {
   // @ts-expect-error TS2564 Definitely assigned in a plugin
   config;
 
-  /** @type {import('./plugins/emotes').Emotes} */
-  // @ts-expect-error TS2564 Definitely assigned in a plugin
-  emotes;
+  /** @type {import('./plugins/emotes').Emotes|null} */
+  emotes = null;
 
   /** @type {import('./plugins/history').HistoryRepository} */
   // @ts-expect-error TS2564 Definitely assigned in a plugin
@@ -197,7 +195,6 @@ class UwaveServer extends EventEmitter {
 
     boot.use(acl);
     boot.use(chat);
-    boot.use(emotes);
     boot.use(motd);
     boot.use(playlists);
     boot.use(users);

--- a/src/controllers/emotes.js
+++ b/src/controllers/emotes.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const toListResponse = require('../utils/toListResponse');
+
+/**
+ * @type {import('../types').Controller}
+ */
+async function getEmotes(req) {
+  const { emotes } = req.uwave;
+
+  const list = await emotes.getEmotes();
+
+  return toListResponse(list, { url: req.fullUrl });
+}
+
+exports.getEmotes = getEmotes;

--- a/src/controllers/emotes.js
+++ b/src/controllers/emotes.js
@@ -8,6 +8,10 @@ const toListResponse = require('../utils/toListResponse');
 async function getEmotes(req) {
   const { emotes } = req.uwave;
 
+  if (!emotes) {
+    return toListResponse([], { url: req.fullUrl });
+  }
+
   const list = await emotes.getEmotes();
 
   return toListResponse(list, { url: req.fullUrl });

--- a/src/plugins/emotes.js
+++ b/src/plugins/emotes.js
@@ -3,6 +3,7 @@
 const { AppTokenAuthProvider } = require('@twurple/auth');
 const { ApiClient } = require('@twurple/api');
 const fetch = require('node-fetch').default;
+const routes = require('../routes/emotes');
 const schema = require('../schemas/emotes.json');
 
 /**
@@ -171,6 +172,7 @@ class Emotes {
  */
 async function emotesPlugin(uw) {
   uw.emotes = new Emotes(uw); // eslint-disable-line no-param-reassign
+  uw.httpApi.use('/emotes', routes());
 }
 
 module.exports = emotesPlugin;

--- a/src/plugins/emotes.js
+++ b/src/plugins/emotes.js
@@ -7,8 +7,15 @@ const routes = require('../routes/emotes');
 const schema = require('../schemas/emotes.json');
 
 /**
- * @typedef {{ clientId: string | null, clientSecret: string | null, bttv: boolean, seventv: boolean, channels: string[] }} TwitchSettings
+ * @typedef {{
+ *   clientId: string | null,
+ *   clientSecret: string | null,
+ *   bttv: boolean,
+ *   seventv: boolean,
+ *   channels: string[],
+ * }} TwitchSettings
  * @typedef {{ twitch: TwitchSettings }} EmotesSettings
+ *
  * @typedef {{ id: string, code: string, imageType: string, animated: boolean }} BTTVEmote
  * @typedef {{ id: string, name: string, data: { animated: boolean } }} SevenTVEmote
  */

--- a/src/plugins/emotes.js
+++ b/src/plugins/emotes.js
@@ -131,6 +131,14 @@ async function loadTTVEmotes(options) {
   return emotes;
 }
 
+/**
+ * EXPERIMENTAL: load emotes from Twitch emote services.
+ *
+ * Before considering this stable:
+ * - error handling must be improved.
+ * - we should also add support for Twitch emotes themselves.
+ * - global emotes from the emote services should be optional.
+ */
 class Emotes {
   #uw;
 

--- a/src/plugins/emotes.js
+++ b/src/plugins/emotes.js
@@ -1,0 +1,139 @@
+'use strict';
+
+const { AppTokenAuthProvider } = require('@twurple/auth');
+const { ApiClient } = require('@twurple/api');
+const fetch = require('node-fetch').default;
+const schema = require('../schemas/emotes.json');
+
+/**
+ * @typedef {{ clientId: string | null, clientSecret: string | null, bttv: boolean, seventv: boolean, channels: string[] }} TwitchSettings
+ * @typedef {{ twitch: TwitchSettings }} EmotesSettings
+ * @typedef {{ id: string, code: string, imageType: string, animated: boolean }} BTTVEmote
+ */
+
+/**
+ * @template {object} T
+ * @param {URL|string} url
+ * @returns {Promise<T>}
+ */
+async function fetchJSON(url) {
+  const res = await fetch(url);
+  const json = await res.json();
+  return json;
+}
+
+/**
+ * @param {string[]} channels
+ * @returns {Promise<Record<string, URL>>}
+ */
+async function loadBTTVEmotes(channels) {
+  /** @type {Record<string, URL>} */
+  const emotes = {};
+
+  /**
+   * @param {string} channelId
+   * @returns {Promise<BTTVEmote[]>}
+   */
+  async function loadChannelEmotes(channelId) {
+    /** @type {{ channelEmotes: BTTVEmote[], sharedEmotes: BTTVEmote[] }} */
+    const channel = await fetchJSON(`https://api.betterttv.net/3/cached/users/twitch/${channelId}`);
+    const { channelEmotes, sharedEmotes } = channel;
+
+    return [...channelEmotes, ...sharedEmotes];
+  }
+
+  const list = await Promise.all([
+    /** @type {Promise<BTTVEmote[]>} */ (fetchJSON('https://api.betterttv.net/3/cached/emotes/global')),
+    ...channels.map((channelId) => loadChannelEmotes(channelId)),
+  ]);
+
+  for (const emote of list.flat()) {
+    emotes[emote.code.replace(/(^:|:$)/g, '')] = new URL(`https://cdn.betterttv.net/emote/${emote.id}/2x`);
+  }
+
+  return emotes;
+}
+
+/**
+ * @param {TwitchSettings} options
+ * @returns {Promise<Record<string, URL>>}
+ */
+async function loadTTVEmotes(options) {
+  /** @type {Record<string, URL>} */
+  const emotes = {};
+
+  if (!options.clientId || !options.clientSecret) {
+    return emotes;
+  }
+
+  const client = new ApiClient({
+    authProvider: new AppTokenAuthProvider(options.clientId, options.clientSecret),
+  });
+
+  const channels = /** @type {string[]} */ ((
+    await Promise.all(options.channels.map(async (channelName) => {
+      const user = await client.users.getUserByName(channelName);
+      return user?.id;
+    }))
+  ).filter((id) => id != null));
+
+  if (options.bttv) {
+    Object.assign(emotes, await loadBTTVEmotes(channels));
+  }
+
+  return emotes;
+}
+
+class Emotes {
+  #uw;
+
+  /** @type {Record<string, URL>} */
+  #emotes = Object.create(null);
+
+  #ready = Promise.resolve();
+
+  /**
+   * @param {import('../Uwave').Boot} uw
+   */
+  constructor(uw) {
+    this.#uw = uw;
+
+    uw.config.register(schema['uw:key'], schema);
+    const unsubscribe = uw.config.subscribe(
+      schema['uw:key'],
+      () => {
+        this.#ready = this.#reloadEmotes();
+      },
+    );
+    uw.onClose(unsubscribe);
+
+    this.#ready = this.#reloadEmotes();
+  }
+
+  async getEmotes() {
+    await this.#ready;
+
+    return Object.entries(this.#emotes).map(([name, url]) => ({ name, url: url.toString() }));
+  }
+
+  async #reloadEmotes() {
+    const config = /** @type {EmotesSettings} */ (await this.#uw.config.get(schema['uw:key']));
+
+    if (config.twitch) {
+      this.#emotes = await loadTTVEmotes(config.twitch);
+    }
+
+    this.#uw.publish('emotes:reload', null);
+  }
+}
+
+/**
+ * @param {import('../Uwave').Boot} uw
+ * @returns {Promise<void>}
+ */
+async function emotesPlugin(uw) {
+  uw.emotes = new Emotes(uw); // eslint-disable-line no-param-reassign
+}
+
+module.exports = emotesPlugin;
+module.exports.Emotes = Emotes;

--- a/src/plugins/emotes.js
+++ b/src/plugins/emotes.js
@@ -10,7 +10,7 @@ const schema = require('../schemas/emotes.json');
  * @typedef {{ clientId: string | null, clientSecret: string | null, bttv: boolean, seventv: boolean, channels: string[] }} TwitchSettings
  * @typedef {{ twitch: TwitchSettings }} EmotesSettings
  * @typedef {{ id: string, code: string, imageType: string, animated: boolean }} BTTVEmote
- * @typedef {{ id: string, name: string }} SevenTVEmote
+ * @typedef {{ id: string, name: string, data: { animated: boolean } }} SevenTVEmote
  */
 
 /**
@@ -83,7 +83,8 @@ async function loadSevenTVEmotes(channels) {
   ]);
 
   for (const emote of list.flat()) {
-    emotes[emote.name] = new URL(`https://cdn.7tv.app/emote/${emote.id}/2x.png`);
+    const ext = emote.data.animated ? 'gif' : 'png';
+    emotes[emote.name] = new URL(`https://cdn.7tv.app/emote/${emote.id}/2x.${ext}`);
   }
 
   return emotes;

--- a/src/redisMessages.ts
+++ b/src/redisMessages.ts
@@ -136,6 +136,8 @@ export type ServerActionParameters = {
     moderatorID: string,
   },
   'http-api:socket:close': string,
+
+  'emotes:reload': null,
 };
 
 export type ServerActions = {

--- a/src/routes/emotes.js
+++ b/src/routes/emotes.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const { Router } = require('express');
+const route = require('../route');
+const controller = require('../controllers/emotes');
+
+function emotesRoutes() {
+  return Router()
+    // GET /emotes/ - List available (non-unicode) emotes.
+    .get(
+      '/',
+      route(controller.getEmotes),
+    );
+}
+
+module.exports = emotesRoutes;

--- a/src/schemas/emotes.json
+++ b/src/schemas/emotes.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://ns.u-wave.net/config/emotes.json#",
+  "uw:key": "u-wave:emotes",
+  "uw:access": "admin",
+  "type": "object",
+  "title": "Emotes",
+  "description": "Add custom emotes for use in the chat.",
+  "properties": {
+    "twitch": {
+      "type": "object",
+      "title": "Twitch Emotes",
+      "properties": {
+        "clientId": {
+          "type": "string",
+          "title": "Twitch App Token: Client ID",
+          "default": null,
+          "nullable": true
+        },
+        "clientSecret": {
+          "type": "string",
+          "title": "Twitch App Token: Client Secret",
+          "default": null,
+          "nullable": true
+        },
+
+        "bttv": {
+          "type": "boolean",
+          "title": "Enable BetterTTV emotes",
+          "default": false
+        },
+        "seventv": {
+          "type": "boolean",
+          "title": "Enable 7TV emotes",
+          "default": false
+        },
+        "channels": {
+          "type": "array",
+          "title": "Channels",
+          "description": "Use emotes from these channel names",
+          "items": { "type": "string" },
+          "default": []
+        }
+      },
+      "default": {}
+    }
+  },
+  "required": []
+}


### PR DESCRIPTION
I keep going back and forth on what to do with custom emote uploads. A Discord-like solution is quite complicated, especially with the "modular"-ish approach we have taken with the backend (which I'm strongly considering undoing).

This, on top of https://github.com/u-wave/web/pull/2515, is a simple inbetween solution that addresses our use cases on https://wlk.yt. We can put our existing custom emotes in a folder. And with this PR, we can load additional emotes from Twitch emote services. For now, it supports BTTV and 7TV. Later we can add support for FFZ and Twitch itself.

I whipped this up in about 2 hours but I'd like to use it on WLK asap. I'm putting it behind a flag so we can test it a bit: run the CLI with `EXPERIMENTAL_EMOTES=true` to enable the feature.