### PR TITLE
Explicitly pass ObjectId to mongoose instead of relying on auto casting

### DIFF
--- a/src/SocketServer.js
+++ b/src/SocketServer.js
@@ -71,7 +71,12 @@ class SocketServer {
     });
 
     uw.after(async () => {
-      await uw.socketServer.initLostConnections();
+      try {
+        await uw.socketServer.initLostConnections();
+      } catch (err) {
+        // No need to prevent startup for this
+        uw.socketServer.#logger.warn({ err }, 'could not initialise lost connections');
+      }
     });
 
     uw.onClose(async () => {


### PR DESCRIPTION
I got invalid data in my local Redis instance and the mongoose auto casting causes an unusable error dump. Casting explicitly ahead of time makes it much clearer.