### PR TITLE
Rename duplicate emotes with a ~N number suffix

### DIFF
--- a/src/plugins/emotes.js
+++ b/src/plugins/emotes.js
@@ -42,7 +42,8 @@ class EmoteMap extends Map {
    * @param {Emote} emote
    */
   insert(emote) {
-    if (this.has(emote.name)) {
+    const prevUrl = this.get(emote.name);
+    if (prevUrl && prevUrl !== emote.url) {
       for (let i = 1; i < 20; i += 1) {
         if (!this.has(`${emote.name}~${i}`)) {
           this.set(`${emote.name}~${i}`, emote.url);

--- a/src/plugins/emotes.js
+++ b/src/plugins/emotes.js
@@ -30,6 +30,31 @@ const schema = JSON.parse(
  */
 
 /**
+ * A Map of emote names to URLs.
+ *
+ * @augments {Map<string, URL>}
+ */
+class EmoteMap extends Map {
+  /**
+   * Add an emote to the map. If an emote with the same name already exists,
+   * this tries to add a numeric suffix to distinguish them.
+   *
+   * @param {Emote} emote
+   */
+  insert(emote) {
+    if (this.has(emote.name)) {
+      for (let i = 1; i < 20; i += 1) {
+        if (!this.has(`${emote.name}~${i}`)) {
+          this.set(`${emote.name}~${i}`, emote.url);
+        }
+      }
+    } else {
+      this.set(emote.name, emote.url);
+    }
+  }
+}
+
+/**
  * @template {object} T
  * @param {URL|string} url
  * @returns {Promise<T>}
@@ -220,8 +245,7 @@ class Emotes {
 
   #logger;
 
-  /** @type {Record<string, URL>} */
-  #emotes = Object.create(null);
+  #emotes = new EmoteMap();
 
   #ready = Promise.resolve();
 
@@ -244,19 +268,25 @@ class Emotes {
     this.#ready = this.#reloadEmotes();
   }
 
+  /** Get all known emotes as an array. */
   async getEmotes() {
     await this.#ready;
 
-    return Object.entries(this.#emotes).map(([name, url]) => ({ name, url: url.toString() }));
+    const emotes = [];
+    for (const [name, url] of this.#emotes) {
+      emotes.push({ name, url: url.toString() });
+    }
+
+    return emotes;
   }
 
   /**
    * @param {TwitchSettings} options
-   * @returns {Promise<Record<string, URL>>}
+   * @returns {Promise<EmoteMap>}
    */
   async #loadTTVEmotes(options) {
     if (!options.clientId || !options.clientSecret) {
-      return {};
+      return new EmoteMap();
     }
 
     const client = new ApiClient({
@@ -292,14 +322,13 @@ class Emotes {
       promises.push(getSevenTVEmotes(channels));
     }
 
-    /** @type {Record<string, URL>} */
-    const emotes = {};
+    const emotes = new EmoteMap();
 
     const results = await Promise.allSettled(promises);
     for (const result of results) {
       if (result.status === 'fulfilled') {
         for (const emote of result.value) {
-          emotes[emote.name] = emote.url;
+          emotes.insert(emote);
         }
       } else {
         this.#logger.warn(result.reason);

--- a/src/plugins/emotes.js
+++ b/src/plugins/emotes.js
@@ -43,10 +43,11 @@ class EmoteMap extends Map {
    */
   insert(emote) {
     const prevUrl = this.get(emote.name);
-    if (prevUrl && prevUrl !== emote.url) {
+    if (prevUrl && prevUrl.href !== emote.url.href) {
       for (let i = 1; i < 20; i += 1) {
         if (!this.has(`${emote.name}~${i}`)) {
           this.set(`${emote.name}~${i}`, emote.url);
+          break;
         }
       }
     } else {


### PR DESCRIPTION
With emotes from different sources it's pretty common to have overlap. This does the Discord thing of adding `~1`, `~2`, etc suffixes to different emotes with the same name.