### PR TITLE
Store waitlist and booth state in SQLite instead of Redis

### DIFF
--- a/src/KeyValue.js
+++ b/src/KeyValue.js
@@ -1,0 +1,52 @@
+import { fromJson, json, jsonb } from './utils/sqlite.js';
+
+export default class KeyValue {
+  #db;
+
+  /** @param {import('./schema.js').Kysely} db */
+  constructor(db) {
+    this.#db = db;
+  }
+
+  /** @param {string} key */
+  async get(key, db = this.#db) {
+    const row = await db.selectFrom('keyval')
+      .select((eb) => json(eb.ref('value')).as('value'))
+      .where('key', '=', key)
+      .executeTakeFirst();
+    if (row == null) {
+      return undefined;
+    }
+    return fromJson(row.value);
+  }
+
+  /**
+   * @param {string} key
+   * @param {import('type-fest').JsonValue} value
+   */
+  async set(key, value, db = this.#db) {
+    await db.insertInto('keyval')
+      .values({ key, value: jsonb(value) })
+      .onConflict((oc) => oc.column('key').doUpdateSet({ value: jsonb(value) }))
+      .execute();
+  }
+
+  /**
+   * Delete a key, returning its previous value if any.
+   *
+   * @param {string} key
+   * @returns {Promise<import('type-fest').JsonValue | undefined>}
+   */
+  async delete(key, db = this.#db) {
+    const existing = await db.deleteFrom('keyval')
+      .where('key', '=', key)
+      .returning((eb) => json(eb.ref('value')).as('value'))
+      .executeTakeFirst();
+
+    if (existing == null) {
+      return undefined;
+    }
+
+    return fromJson(existing.value);
+  }
+}

--- a/src/Uwave.js
+++ b/src/Uwave.js
@@ -20,7 +20,7 @@ import acl from './plugins/acl.js';
 import waitlist from './plugins/waitlist.js';
 import passport from './plugins/passport.js';
 import migrations from './plugins/migrations.js';
-import { SqliteDateColumnsPlugin, connect as connectSqlite } from './utils/sqlite.js';
+import { SqliteDateColumnsPlugin, connect as connectSqlite, fromJson, json, jsonb } from './utils/sqlite.js';
 
 const DEFAULT_SQLITE_PATH = './uwave.sqlite';
 const DEFAULT_REDIS_URL = 'redis://localhost:6379';
@@ -179,6 +179,37 @@ class UwaveServer extends EventEmitter {
       this.redis.quit(),
       this.db.destroy(),
     ]));
+
+    class KeyValue {
+      #db;
+
+      /** @param {Kysely<import('./schema.js').Database>} db */
+      constructor(db) {
+        this.#db = db;
+      }
+
+      /** @param {string} key */
+      async get(key, db = this.#db) {
+        const row = await db.selectFrom('keyval')
+          .select((eb) => json(eb.ref('value')).as('value'))
+          .where('key', '=', key)
+          .executeTakeFirst();
+        return row != null ? fromJson(row.value) : null;
+      }
+
+      /**
+       * @param {string} key
+       * @param {import('type-fest').JsonValue} value
+       */
+      async set(key, value, db = this.#db) {
+        await db.insertInto('keyval')
+          .values({ key, value: jsonb(value) })
+          .onConflict((oc) => oc.column('key').doUpdateSet({ value: jsonb(value) }))
+          .execute();
+      }
+    }
+
+    this.keyv = new KeyValue(this.db);
 
     boot.use(migrations);
     boot.use(configStore);

--- a/src/Uwave.js
+++ b/src/Uwave.js
@@ -7,6 +7,7 @@ import { CamelCasePlugin, Kysely, SqliteDialect } from 'kysely';
 import httpApi, { errorHandling } from './HttpApi.js';
 import SocketServer from './SocketServer.js';
 import { Source } from './Source.js';
+import KeyValue from './KeyValue.js';
 import { i18n } from './locale.js';
 import configStore from './plugins/configStore.js';
 import booth from './plugins/booth.js';
@@ -20,7 +21,7 @@ import acl from './plugins/acl.js';
 import waitlist from './plugins/waitlist.js';
 import passport from './plugins/passport.js';
 import migrations from './plugins/migrations.js';
-import { SqliteDateColumnsPlugin, connect as connectSqlite, fromJson, json, jsonb } from './utils/sqlite.js';
+import { SqliteDateColumnsPlugin, connect as connectSqlite } from './utils/sqlite.js';
 
 const DEFAULT_SQLITE_PATH = './uwave.sqlite';
 const DEFAULT_REDIS_URL = 'redis://localhost:6379';
@@ -179,35 +180,6 @@ class UwaveServer extends EventEmitter {
       this.redis.quit(),
       this.db.destroy(),
     ]));
-
-    class KeyValue {
-      #db;
-
-      /** @param {Kysely<import('./schema.js').Database>} db */
-      constructor(db) {
-        this.#db = db;
-      }
-
-      /** @param {string} key */
-      async get(key, db = this.#db) {
-        const row = await db.selectFrom('keyval')
-          .select((eb) => json(eb.ref('value')).as('value'))
-          .where('key', '=', key)
-          .executeTakeFirst();
-        return row != null ? fromJson(row.value) : null;
-      }
-
-      /**
-       * @param {string} key
-       * @param {import('type-fest').JsonValue} value
-       */
-      async set(key, value, db = this.#db) {
-        await db.insertInto('keyval')
-          .values({ key, value: jsonb(value) })
-          .onConflict((oc) => oc.column('key').doUpdateSet({ value: jsonb(value) }))
-          .execute();
-      }
-    }
 
     this.keyv = new KeyValue(this.db);
 

--- a/src/controllers/booth.js
+++ b/src/controllers/booth.js
@@ -19,8 +19,8 @@ import { Permissions } from '../plugins/acl.js';
  * @typedef {import('../schema').HistoryEntryID} HistoryEntryID
  */
 
-const REDIS_HISTORY_ID = 'booth:historyID';
-const REDIS_CURRENT_DJ_ID = 'booth:currentDJ';
+const KEY_HISTORY_ID = 'booth:historyID';
+const KEY_CURRENT_DJ_ID = 'booth:currentDJ';
 
 /**
  * @param {import('../Uwave.js').default} uw
@@ -70,15 +70,15 @@ async function getBooth(req) {
 /**
  * @param {import('../Uwave.js').default} uw
  */
-function getCurrentDJ(uw) {
-  return /** @type {Promise<UserID|null>} */ (uw.redis.get(REDIS_CURRENT_DJ_ID));
+function getCurrentDJ(uw, tx = uw.db) {
+  return /** @type {Promise<UserID|null>} */ (uw.keyv.get(KEY_CURRENT_DJ_ID, tx));
 }
 
 /**
  * @param {import('../Uwave.js').default} uw
  */
-function getCurrentHistoryID(uw) {
-  return /** @type {Promise<HistoryEntryID|null>} */ (uw.redis.get(REDIS_HISTORY_ID));
+function getCurrentHistoryID(uw, tx = uw.db) {
+  return /** @type {Promise<HistoryEntryID|null>} */ (uw.keyv.get(KEY_HISTORY_ID, tx));
 }
 
 /**

--- a/src/migrations/002-sql.cjs
+++ b/src/migrations/002-sql.cjs
@@ -16,6 +16,11 @@ async function up({ context: uw }) {
     .addColumn('value', 'jsonb')
     .execute();
 
+  await db.schema.createTable('keyval')
+    .addColumn('key', 'text', (col) => col.primaryKey())
+    .addColumn('value', 'jsonb')
+    .execute();
+
   await db.schema.createTable('media')
     .addColumn('id', 'uuid', (col) => col.primaryKey())
     .addColumn('source_type', 'text', (col) => col.notNull())

--- a/src/migrations/002-sql.cjs
+++ b/src/migrations/002-sql.cjs
@@ -16,11 +16,6 @@ async function up({ context: uw }) {
     .addColumn('value', 'jsonb')
     .execute();
 
-  await db.schema.createTable('keyval')
-    .addColumn('key', 'text', (col) => col.primaryKey())
-    .addColumn('value', 'jsonb')
-    .execute();
-
   await db.schema.createTable('media')
     .addColumn('id', 'uuid', (col) => col.primaryKey())
     .addColumn('source_type', 'text', (col) => col.notNull())

--- a/src/migrations/004-keyval.cjs
+++ b/src/migrations/004-keyval.cjs
@@ -1,0 +1,27 @@
+'use strict';
+
+/**
+ * @param {import('umzug').MigrationParams<import('../Uwave').default>} params
+ */
+async function up({ context: uw }) {
+  const { db } = uw;
+
+  await db.schema.createTable('keyval')
+    .addColumn('key', 'text', (col) => col.primaryKey())
+    .addColumn('value', 'jsonb')
+    .execute();
+
+  // Intentionally not populating it, no big deal to lose waitlist / current dj state
+  // with our current user numbers :)
+}
+
+/**
+ * @param {import('umzug').MigrationParams<import('../Uwave').default>} params
+ */
+async function down({ context: uw }) {
+  const { db } = uw;
+
+  await db.schema.dropTable('keyval').execute();
+}
+
+module.exports = { up, down };

--- a/src/plugins/booth.js
+++ b/src/plugins/booth.js
@@ -109,9 +109,11 @@ class Booth {
   async getCurrentEntry(tx = this.#uw.db) {
     const entry = await tx.selectFrom('keyval')
       .where('key', '=', KEY_HISTORY_ID)
-      .innerJoin('historyEntries', (join) => join
-        .on((eb) => sql`${eb.ref('value')}->>'$'`, '=', 'historyEntries.id')
-      )
+      .innerJoin('historyEntries', (join) => join.on(
+        (eb) => sql`${eb.ref('value')}->>'$'`,
+        '=',
+        (eb) => eb.ref('historyEntries.id'),
+      ))
       .innerJoin('media', 'historyEntries.mediaID', 'media.id')
       .innerJoin('users', 'historyEntries.userID', 'users.id')
       .select([
@@ -149,10 +151,6 @@ class Booth {
           .select((eb) => jsonGroupArray(eb.ref('userID')).as('userIDs'))
           .as('favorites'),
       ])
-      .$call((s) => {
-        console.log(s.compile());
-        return s;
-      })
       .executeTakeFirst();
 
     return entry ? {
@@ -503,23 +501,28 @@ class Booth {
    * @param {boolean} remove
    */
   async setRemoveAfterCurrentPlay(user, remove) {
-    // TODO
-    const newValue = await this.#uw.redis['uw:removeAfterCurrentPlay'](
-      ...REMOVE_AFTER_CURRENT_PLAY_SCRIPT.keys,
-      user.id,
-      remove,
-    );
-    return newValue === 1;
+    const newValue = await this.#uw.db.transaction().execute(async (tx) => {
+      const currentDJ = /** @type {UserID|undefined} */ (await this.#uw.keyv.get(KEY_CURRENT_DJ_ID, tx));
+      if (currentDJ === user.id) {
+        if (remove) {
+          await this.#uw.keyv.set(KEY_REMOVE_AFTER_CURRENT_PLAY, true, tx);
+          return true;
+        }
+        await this.#uw.keyv.delete(KEY_REMOVE_AFTER_CURRENT_PLAY, tx);
+        return false;
+      } else {
+        throw new Error('You are not currently playing');
+      }
+    });
+    return newValue;
   }
 
   /**
    * @param {User} user
    */
   async getRemoveAfterCurrentPlay(user, tx = this.#uw.db) {
-    /** @type {string|undefined} */
-    const currentDJ = await this.#uw.keyv.get(KEY_CURRENT_DJ_ID, tx);
-    /** @type {boolean|undefined} */
-    const removeAfterCurrentPlay = await this.#uw.keyv.get(KEY_REMOVE_AFTER_CURRENT_PLAY, tx);
+    const currentDJ = /** @type {UserID|undefined} */ (await this.#uw.keyv.get(KEY_CURRENT_DJ_ID, tx));
+    const removeAfterCurrentPlay = /** @type {boolean|undefined} */ (await this.#uw.keyv.get(KEY_REMOVE_AFTER_CURRENT_PLAY, tx));
 
     if (currentDJ === user.id) {
       return removeAfterCurrentPlay != null;

--- a/src/plugins/booth.js
+++ b/src/plugins/booth.js
@@ -163,7 +163,8 @@ class Booth {
    * @param {{ remove?: boolean }} options
    */
   async #getNextDJ(options, tx = this.#uw.db) {
-    let userID = /** @type {UserID|null} */ (await this.#uw.redis.lindex('waitlist', 0));
+    const waitlist = await this.#uw.waitlist.getUserIDs();
+    let userID = waitlist.at(0) ?? null;
     if (!userID && !options.remove) {
       // If the waitlist is empty, the current DJ will play again immediately.
       userID = /** @type {UserID|null} */ (await this.#uw.keyv.get(KEY_CURRENT_DJ_ID, tx));
@@ -220,15 +221,7 @@ class Booth {
    * @param {{ remove?: boolean }} options
    */
   async #cycleWaitlist(previous, options) {
-    const waitlistLen = await this.#uw.redis.llen('waitlist');
-    if (waitlistLen > 0) {
-      await this.#uw.redis.lpop('waitlist');
-      if (previous && !options.remove) {
-        // The previous DJ should only be added to the waitlist again if it was
-        // not empty. If it was empty, the previous DJ is already in the booth.
-        await this.#uw.redis.rpush('waitlist', previous);
-      }
-    }
+    await this.#uw.waitlist.cycle(previous, options);
   }
 
   async clear(tx = this.#uw.db) {
@@ -362,7 +355,7 @@ class Booth {
     const { playlists } = this.#uw;
 
     const publish = opts.publish ?? true;
-    const removeAfterCurrent = (await this.#uw.redis.del(KEY_REMOVE_AFTER_CURRENT_PLAY)) === 1;
+    const removeAfterCurrent = (await this.#uw.keyv.delete(KEY_REMOVE_AFTER_CURRENT_PLAY)) === true;
     const remove = opts.remove || removeAfterCurrent || (
       !await this.#uw.waitlist.isCycleEnabled()
     );

--- a/src/plugins/booth.js
+++ b/src/plugins/booth.js
@@ -21,28 +21,6 @@ const KEY_HISTORY_ID = 'booth:historyID';
 const KEY_CURRENT_DJ_ID = 'booth:currentDJ';
 const KEY_REMOVE_AFTER_CURRENT_PLAY = 'booth:removeAfterCurrentPlay';
 
-const REMOVE_AFTER_CURRENT_PLAY_SCRIPT = {
-  keys: [KEY_CURRENT_DJ_ID, KEY_REMOVE_AFTER_CURRENT_PLAY],
-  lua: `
-    local k_dj = KEYS[1]
-    local k_remove = KEYS[2]
-    local user_id = ARGV[1]
-    local value = ARGV[2]
-    local current_dj_id = redis.call('GET', k_dj)
-    if current_dj_id == user_id then
-      if value == 'true' then
-        redis.call('SET', k_remove, 'true')
-        return 1
-      else
-        redis.call('DEL', k_remove)
-        return 0
-      end
-    else
-      return redis.error_reply('You are not currently playing')
-    end
-  `,
-};
-
 class Booth {
   #uw;
 
@@ -63,11 +41,6 @@ class Booth {
     this.#uw = uw;
     this.#locker = new RedLock([this.#uw.redis]);
     this.#logger = uw.logger.child({ ns: 'uwave:booth' });
-
-    uw.redis.defineCommand('uw:removeAfterCurrentPlay', {
-      numberOfKeys: REMOVE_AFTER_CURRENT_PLAY_SCRIPT.keys.length,
-      lua: REMOVE_AFTER_CURRENT_PLAY_SCRIPT.lua,
-    });
   }
 
   /** @internal */

--- a/src/plugins/booth.js
+++ b/src/plugins/booth.js
@@ -475,7 +475,9 @@ class Booth {
    */
   async setRemoveAfterCurrentPlay(user, remove) {
     const newValue = await this.#uw.db.transaction().execute(async (tx) => {
-      const currentDJ = /** @type {UserID|undefined} */ (await this.#uw.keyv.get(KEY_CURRENT_DJ_ID, tx));
+      const currentDJ = /** @type {UserID|undefined} */ (
+        await this.#uw.keyv.get(KEY_CURRENT_DJ_ID, tx)
+      );
       if (currentDJ === user.id) {
         if (remove) {
           await this.#uw.keyv.set(KEY_REMOVE_AFTER_CURRENT_PLAY, true, tx);
@@ -494,8 +496,12 @@ class Booth {
    * @param {User} user
    */
   async getRemoveAfterCurrentPlay(user, tx = this.#uw.db) {
-    const currentDJ = /** @type {UserID|undefined} */ (await this.#uw.keyv.get(KEY_CURRENT_DJ_ID, tx));
-    const removeAfterCurrentPlay = /** @type {boolean|undefined} */ (await this.#uw.keyv.get(KEY_REMOVE_AFTER_CURRENT_PLAY, tx));
+    const currentDJ = /** @type {UserID|undefined} */ (
+      await this.#uw.keyv.get(KEY_CURRENT_DJ_ID, tx)
+    );
+    const removeAfterCurrentPlay = /** @type {boolean|undefined} */ (
+      await this.#uw.keyv.get(KEY_REMOVE_AFTER_CURRENT_PLAY, tx)
+    );
 
     if (currentDJ === user.id) {
       return removeAfterCurrentPlay != null;

--- a/src/plugins/booth.js
+++ b/src/plugins/booth.js
@@ -1,4 +1,5 @@
 import RedLock from 'redlock';
+import { sql } from 'kysely';
 import { EmptyPlaylistError, PlaylistItemNotFoundError } from '../errors/index.js';
 import routes from '../routes/booth.js';
 import { randomUUID } from 'node:crypto';
@@ -16,12 +17,12 @@ import { fromJson, jsonb, jsonGroupArray } from '../utils/sqlite.js';
  */
 
 const REDIS_ADVANCING = 'booth:advancing';
-const REDIS_HISTORY_ID = 'booth:historyID';
-const REDIS_CURRENT_DJ_ID = 'booth:currentDJ';
-const REDIS_REMOVE_AFTER_CURRENT_PLAY = 'booth:removeAfterCurrentPlay';
+const KEY_HISTORY_ID = 'booth:historyID';
+const KEY_CURRENT_DJ_ID = 'booth:currentDJ';
+const KEY_REMOVE_AFTER_CURRENT_PLAY = 'booth:removeAfterCurrentPlay';
 
 const REMOVE_AFTER_CURRENT_PLAY_SCRIPT = {
-  keys: [REDIS_CURRENT_DJ_ID, REDIS_REMOVE_AFTER_CURRENT_PLAY],
+  keys: [KEY_CURRENT_DJ_ID, KEY_REMOVE_AFTER_CURRENT_PLAY],
   lua: `
     local k_dj = KEYS[1]
     local k_remove = KEYS[2]
@@ -106,12 +107,11 @@ class Booth {
   }
 
   async getCurrentEntry(tx = this.#uw.db) {
-    const historyID = /** @type {HistoryEntryID} */ (await this.#uw.redis.get(REDIS_HISTORY_ID));
-    if (!historyID) {
-      return null;
-    }
-
-    const entry = await tx.selectFrom('historyEntries')
+    const entry = await tx.selectFrom('keyval')
+      .where('key', '=', KEY_HISTORY_ID)
+      .innerJoin('historyEntries', (join) => join
+        .on((eb) => sql`${eb.ref('value')}->>'$'`, '=', 'historyEntries.id')
+      )
       .innerJoin('media', 'historyEntries.mediaID', 'media.id')
       .innerJoin('users', 'historyEntries.userID', 'users.id')
       .select([
@@ -149,7 +149,10 @@ class Booth {
           .select((eb) => jsonGroupArray(eb.ref('userID')).as('userIDs'))
           .as('favorites'),
       ])
-      .where('historyEntries.id', '=', historyID)
+      .$call((s) => {
+        console.log(s.compile());
+        return s;
+      })
       .executeTakeFirst();
 
     return entry ? {
@@ -192,7 +195,7 @@ class Booth {
     let userID = /** @type {UserID|null} */ (await this.#uw.redis.lindex('waitlist', 0));
     if (!userID && !options.remove) {
       // If the waitlist is empty, the current DJ will play again immediately.
-      userID = /** @type {UserID|null} */ (await this.#uw.redis.get(REDIS_CURRENT_DJ_ID));
+      userID = /** @type {UserID|null} */ (await this.#uw.keyv.get(KEY_CURRENT_DJ_ID, tx));
     }
     if (!userID) {
       return null;
@@ -257,23 +260,19 @@ class Booth {
     }
   }
 
-  async clear() {
-    await this.#uw.redis.del(
-      REDIS_HISTORY_ID,
-      REDIS_CURRENT_DJ_ID,
-      REDIS_REMOVE_AFTER_CURRENT_PLAY,
-    );
+  async clear(tx = this.#uw.db) {
+    await this.#uw.keyv.delete(KEY_REMOVE_AFTER_CURRENT_PLAY, tx);
+    await this.#uw.keyv.delete(KEY_HISTORY_ID, tx);
+    await this.#uw.keyv.delete(KEY_CURRENT_DJ_ID, tx);
   }
 
   /**
    * @param {{ historyEntry: { id: HistoryEntryID }, user: { id: UserID } }} next
    */
-  async #update(next) {
-    await this.#uw.redis.multi()
-      .del(REDIS_REMOVE_AFTER_CURRENT_PLAY)
-      .set(REDIS_HISTORY_ID, next.historyEntry.id)
-      .set(REDIS_CURRENT_DJ_ID, next.user.id)
-      .exec();
+  async #update(next, tx = this.#uw.db) {
+    await this.#uw.keyv.delete(KEY_REMOVE_AFTER_CURRENT_PLAY, tx);
+    await this.#uw.keyv.set(KEY_HISTORY_ID, next.historyEntry.id, tx);
+    await this.#uw.keyv.set(KEY_CURRENT_DJ_ID, next.user.id, tx);
   }
 
   #maybeStop() {
@@ -392,7 +391,7 @@ class Booth {
     const { playlists } = this.#uw;
 
     const publish = opts.publish ?? true;
-    const removeAfterCurrent = (await this.#uw.redis.del(REDIS_REMOVE_AFTER_CURRENT_PLAY)) === 1;
+    const removeAfterCurrent = (await this.#uw.redis.del(KEY_REMOVE_AFTER_CURRENT_PLAY)) === 1;
     const remove = opts.remove || removeAfterCurrent || (
       !await this.#uw.waitlist.isCycleEnabled()
     );
@@ -504,6 +503,7 @@ class Booth {
    * @param {boolean} remove
    */
   async setRemoveAfterCurrentPlay(user, remove) {
+    // TODO
     const newValue = await this.#uw.redis['uw:removeAfterCurrentPlay'](
       ...REMOVE_AFTER_CURRENT_PLAY_SCRIPT.keys,
       user.id,
@@ -515,11 +515,12 @@ class Booth {
   /**
    * @param {User} user
    */
-  async getRemoveAfterCurrentPlay(user) {
-    const [currentDJ, removeAfterCurrentPlay] = await this.#uw.redis.mget(
-      REDIS_CURRENT_DJ_ID,
-      REDIS_REMOVE_AFTER_CURRENT_PLAY,
-    );
+  async getRemoveAfterCurrentPlay(user, tx = this.#uw.db) {
+    /** @type {string|undefined} */
+    const currentDJ = await this.#uw.keyv.get(KEY_CURRENT_DJ_ID, tx);
+    /** @type {boolean|undefined} */
+    const removeAfterCurrentPlay = await this.#uw.keyv.get(KEY_REMOVE_AFTER_CURRENT_PLAY, tx);
+
     if (currentDJ === user.id) {
       return removeAfterCurrentPlay != null;
     }

--- a/src/plugins/waitlist.js
+++ b/src/plugins/waitlist.js
@@ -224,6 +224,8 @@ class Waitlist {
     }
 
     waitlist.splice(previousPosition, 1);
+    // `position` might be _past_ the end of the array,
+    // in which case this is equivalent to a `.push`.
     waitlist.splice(position, 0, user.id);
 
     await this.#uw.keyv.set(KEY_WAITLIST, waitlist);

--- a/src/plugins/waitlist.js
+++ b/src/plugins/waitlist.js
@@ -15,68 +15,15 @@ const schema = JSON.parse(
   fs.readFileSync(new URL('../schemas/waitlist.json', import.meta.url), 'utf8'),
 );
 
+const KEY_WAITLIST = 'waitlist';
+const KEY_CURRENT_DJ_ID = 'booth:currentDJ';
+const KEY_HISTORY_ID = 'booth:historyID';
+
 /**
  * @typedef {import('../schema.js').UserID} UserID
  * @typedef {import('../schema.js').User} User
  * @typedef {{ cycle: boolean, locked: boolean }} WaitlistSettings
  */
-
-const ADD_TO_WAITLIST_SCRIPT = {
-  keys: ['waitlist', 'booth:currentDJ'],
-  lua: `
-    local k_waitlist = KEYS[1]
-    local k_dj = KEYS[2]
-    local user_id = ARGV[1]
-    local position = ARGV[2]
-    local is_in_waitlist = redis.call('LPOS', k_waitlist, user_id)
-    local current_dj = redis.call('GET', k_dj)
-    if is_in_waitlist or current_dj == user_id then
-      return { err = '${AlreadyInWaitlistError.code}' }
-    end
-
-    local before_id = nil
-    if position then
-      before_id = redis.call('LINDEX', k_waitlist, position)
-    end
-
-    if before_id then
-      redis.call('LINSERT', k_waitlist, 'BEFORE', before_id)
-    else
-      redis.call('RPUSH', k_waitlist, user_id)
-    end
-
-    return redis.call('LRANGE', k_waitlist, 0, -1)
-  `,
-};
-
-const MOVE_WAITLIST_SCRIPT = {
-  keys: ['waitlist', 'booth:currentDJ'],
-  lua: `
-    local k_waitlist = KEYS[1]
-    local k_dj = KEYS[2]
-    local user_id = ARGV[1]
-    local position = ARGV[2]
-    local is_in_waitlist = redis.call('LPOS', k_waitlist, user_id)
-    if not is_in_waitlist then
-      return { err = '${UserNotInWaitlistError.code}' }
-    end
-    local current_dj = redis.call('GET', k_dj)
-    if current_dj == user_id then
-      return { err = '${UserIsPlayingError.code}' }
-    end
-
-    local before_id = redis.call('LINDEX', k_waitlist, position)
-
-    redis.call('LREM', k_waitlist, 0, user_id);
-    if before_id then
-      redis.call('LINSERT', k_waitlist, 'BEFORE', before_id, user_id);
-    else
-      redis.call('RPUSH', k_waitlist, user_id)
-    end
-
-    return redis.call('LRANGE', k_waitlist, 0, -1)
-  `,
-};
 
 class Waitlist {
   #uw;
@@ -88,14 +35,6 @@ class Waitlist {
     this.#uw = uw;
 
     uw.config.register(schema['uw:key'], schema);
-    uw.redis.defineCommand('uw:addToWaitlist', {
-      numberOfKeys: ADD_TO_WAITLIST_SCRIPT.keys.length,
-      lua: ADD_TO_WAITLIST_SCRIPT.lua,
-    });
-    uw.redis.defineCommand('uw:moveWaitlist', {
-      numberOfKeys: MOVE_WAITLIST_SCRIPT.keys.length,
-      lua: MOVE_WAITLIST_SCRIPT.lua,
-    });
 
     const unsubscribe = uw.config.subscribe(
       schema['uw:key'],
@@ -121,20 +60,20 @@ class Waitlist {
   }
 
   async #isBoothEmpty() {
-    return !(await this.#uw.redis.get('booth:historyID'));
+    return !(await this.#uw.keyv.get(KEY_HISTORY_ID));
   }
 
   /**
    * @param {User} user
    * @returns {Promise<boolean>}
    */
-  async #hasPlayablePlaylist(user) {
+  async #hasPlayablePlaylist(user, tx = this.#uw.db) {
     const { playlists } = this.#uw;
     if (!user.activePlaylistID) {
       return false;
     }
 
-    const playlist = await playlists.getUserPlaylist(user, user.activePlaylistID);
+    const playlist = await playlists.getUserPlaylist(user, user.activePlaylistID, tx);
     return playlist && playlist.size > 0;
   }
 
@@ -167,8 +106,28 @@ class Waitlist {
   /**
    * @returns {Promise<UserID[]>}
    */
-  getUserIDs() {
-    return /** @type {Promise<UserID[]>} */ (this.#uw.redis.lrange('waitlist', 0, -1));
+  async getUserIDs(tx = this.#uw.db) {
+    const userIDs = /** @type {UserID[] | null} */ (await this.#uw.keyv.get(KEY_WAITLIST, tx));
+    return userIDs ?? [];
+  }
+
+  /**
+   * @param {UserID|null} previous
+   * @param {{ remove?: boolean }} options
+   */
+  async cycle(previous, options) {
+    // TODO: This must happen in a transaction
+    const waitlist = await this.getUserIDs();
+    if (waitlist.length > 0) {
+      waitlist.shift();
+      if (previous && !options.remove) {
+        // The previous DJ should only be added to the waitlist again if it was
+        // not empty. If it was empty, the previous DJ is already in the booth.
+        waitlist.push(previous);
+      }
+
+      await this.#uw.keyv.set(KEY_WAITLIST, waitlist);
+    }
   }
 
   /**
@@ -202,27 +161,31 @@ class Waitlist {
       throw new EmptyPlaylistError();
     }
 
-    try {
-      const waitlist = /** @type {UserID[]} */ (await this.#uw.redis['uw:addToWaitlist'](...ADD_TO_WAITLIST_SCRIPT.keys, user.id));
+    const waitlist = await this.getUserIDs();
+    const isInWaitlist = waitlist.includes(user.id);
+    const currentDJ = /** @type {UserID|null} */ (
+      await this.#uw.keyv.get(KEY_CURRENT_DJ_ID)
+    );
+    if (isInWaitlist || currentDJ === user.id) {
+      throw new AlreadyInWaitlistError();
+    }
 
-      if (isAddingOtherUser) {
-        this.#uw.publish('waitlist:add', {
-          userID: user.id,
-          moderatorID: moderator.id,
-          position: waitlist.indexOf(user.id),
-          waitlist,
-        });
-      } else {
-        this.#uw.publish('waitlist:join', {
-          userID: user.id,
-          waitlist,
-        });
-      }
-    } catch (error) {
-      if (error.message === AlreadyInWaitlistError.code) {
-        throw new AlreadyInWaitlistError();
-      }
-      throw error;
+    waitlist.push(user.id);
+
+    await this.#uw.keyv.set(KEY_WAITLIST, waitlist);
+
+    if (isAddingOtherUser) {
+      this.#uw.publish('waitlist:add', {
+        userID: user.id,
+        moderatorID: moderator.id,
+        position: waitlist.indexOf(user.id),
+        waitlist,
+      });
+    } else {
+      this.#uw.publish('waitlist:join', {
+        userID: user.id,
+        waitlist,
+      });
     }
 
     if (await this.#isBoothEmpty()) {
@@ -248,24 +211,29 @@ class Waitlist {
       throw new EmptyPlaylistError();
     }
 
-    try {
-      const waitlist = /** @type {UserID[]} */ (await this.#uw.redis['uw:moveWaitlist'](...MOVE_WAITLIST_SCRIPT.keys, user.id, position));
-
-      this.#uw.publish('waitlist:move', {
-        userID: user.id,
-        moderatorID: moderator.id,
-        position: waitlist.indexOf(user.id),
-        waitlist,
-      });
-    } catch (error) {
-      if (error.message === UserNotInWaitlistError.code) {
-        throw new UserNotInWaitlistError({ id: user.id });
-      }
-      if (error.message === UserIsPlayingError.code) {
-        throw new UserIsPlayingError({ id: user.id });
-      }
-      throw error;
+    const waitlist = await this.getUserIDs();
+    const previousPosition = waitlist.indexOf(user.id);
+    if (previousPosition === -1) {
+      throw new UserNotInWaitlistError({ id: user.id });
     }
+    const currentDJ = /** @type {UserID|null} */ (
+      await this.#uw.keyv.get(KEY_CURRENT_DJ_ID)
+    );
+    if (currentDJ === user.id) {
+      throw new UserIsPlayingError({ id: user.id });
+    }
+
+    waitlist.splice(previousPosition, 1);
+    waitlist.splice(position, 0, user.id);
+
+    await this.#uw.keyv.set(KEY_WAITLIST, waitlist);
+
+    this.#uw.publish('waitlist:move', {
+      userID: user.id,
+      moderatorID: moderator.id,
+      position: waitlist.indexOf(user.id),
+      waitlist,
+    });
   }
 
   /**
@@ -287,12 +255,23 @@ class Waitlist {
       });
     }
 
-    const removedCount = await this.#uw.redis.lrem('waitlist', 0, user.id);
-    if (removedCount === 0) {
-      throw new UserNotInWaitlistError({ id: user.id });
-    }
+    const waitlist = await this.#uw.db.transaction().execute(async (tx) => {
+      const waitlist = await this.getUserIDs(tx);
+      let index;
+      let removedCount = 0;
+      while ((index = waitlist.indexOf(user.id)) !== -1) {
+        waitlist.splice(index, 1);
+        removedCount += 1;
+      }
 
-    const waitlist = await this.getUserIDs();
+      if (removedCount === 0) {
+        throw new UserNotInWaitlistError({ id: user.id });
+      }
+
+      await this.#uw.keyv.set(KEY_WAITLIST, waitlist, tx);
+      return waitlist;
+    });
+
     if (isRemoving) {
       this.#uw.publish('waitlist:remove', {
         userID: user.id,
@@ -312,7 +291,7 @@ class Waitlist {
    * @returns {Promise<void>}
    */
   async clear({ moderator }) {
-    await this.#uw.redis.del('waitlist');
+    await this.#uw.keyv.delete(KEY_WAITLIST);
 
     const waitlist = await this.getUserIDs();
     if (waitlist.length !== 0) {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -145,12 +145,18 @@ export interface ConfigurationTable {
   value: JSONB<JsonObject>,
 }
 
+export interface KeyvalTable {
+  key: string,
+  value: JSONB<JsonValue>,
+}
+
 export interface MigrationTable {
   name: string,
 }
 
 export interface Database {
   configuration: ConfigurationTable,
+  keyval: KeyvalTable,
   migrations: MigrationTable,
   media: MediaTable,
   users: UserTable,

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ import type { JsonObject } from 'type-fest';
 import type { Request as ExpressRequest, Response as ExpressResponse } from 'express';
 import type UwaveServer from './Uwave.js';
 import type { HttpApi } from './HttpApi.js';
-import type { UserID, User as UwaveUser } from './schema.js';
+import type { User as UwaveUser } from './schema.js';
 import type { AuthenticateOptions } from './controllers/authenticate.js';
 
 // Add üWave specific request properties.
@@ -30,18 +30,6 @@ declare global {
       /** A session ID provided through some other means than the actual session. */
       sessionID?: string;
     }
-  }
-}
-
-// Declare custom commands.
-declare module 'ioredis' {
-  interface Redis {
-    /** Run the add-to-waitlist script, declared in src/plugins/waitlist.js. */
-    'uw:addToWaitlist'(...args: [...keys: string[], userId: UserID]): Promise<string[]>;
-    /** Run the move-waitlist script, declared in src/plugins/waitlist.js. */
-    'uw:moveWaitlist'(...args: [...keys: string[], userId: UserID, position: number]): Promise<string[]>;
-    /** Run the remove-after-current-play script, declared in src/plugins/booth.js. */
-    'uw:removeAfterCurrentPlay'(...args: [...keys: string[], userId: UserID, remove: boolean]): Promise<0 | 1>;
   }
 }
 

--- a/src/utils/skipIfCurrentDJ.js
+++ b/src/utils/skipIfCurrentDJ.js
@@ -2,7 +2,7 @@
  * @param {import('../Uwave.js').default} uw
  */
 function getCurrentDJ(uw) {
-  return uw.redis.get('booth:currentDJ');
+  return uw.keyv.get('booth:currentDJ');
 }
 
 /**

--- a/test/waitlist.mjs
+++ b/test/waitlist.mjs
@@ -408,4 +408,148 @@ describe('Waitlist', () => {
       sinon.assert.match(nextWaitlist.body.data, []);
     });
   });
+
+  describe('PUT /waitlist/move', () => {
+    it('requires authentication', async () => {
+      await supertest(uw.server)
+        .put('/api/waitlist/move')
+        .expect(401);
+    });
+
+    it('validates input', async () => {
+      const token = await uw.test.createTestSessionToken(user);
+      await uw.acl.createRole('waitlistMover', ['waitlist.move']);
+      await uw.acl.allow(user, ['waitlistMover']);
+
+      // `userID` must be a UUID.
+      await supertest(uw.server)
+        .put('/api/waitlist/move')
+        .set('Cookie', `uwsession=${token}`)
+        .send({ userID: null })
+        .expect(400);
+
+      // body must be JSON.
+      await supertest(uw.server)
+        .put('/api/waitlist/move')
+        .set('Cookie', `uwsession=${token}`)
+        .expect(400);
+
+      // `position` must be 0 or above.
+      await supertest(uw.server)
+        .put('/api/waitlist/move')
+        .set('Cookie', `uwsession=${token}`)
+        .send({ userID: user.id, position: -1 })
+        .expect(400);
+    });
+
+    it('requires the waitlist.move role', async () => {
+      // Put a few users in the list
+      const users = await createUsers(4);
+      await Promise.all(users.map(createTestPlaylistItem));
+      for (const u of users) {
+        await uw.waitlist.addUser(u.id);
+      }
+
+      const token = await uw.test.createTestSessionToken(user);
+      await uw.acl.allow(user, ['user']);
+
+      const testSubject = users[3];
+
+      await supertest(uw.server)
+        .put('/api/waitlist/move')
+        .set('Cookie', `uwsession=${token}`)
+        .send({ userID: testSubject.id, position: 1 })
+        .expect(403);
+
+      await uw.acl.createRole('mover', ['waitlist.move']);
+      await uw.acl.allow(user, ['mover']);
+
+      await supertest(uw.server)
+        .put('/api/waitlist/move')
+        .set('Cookie', `uwsession=${token}`)
+        .send({ userID: testSubject.id, position: 1 })
+        .expect(200);
+    });
+
+    it('moves user to the given position', async () => {
+      // Put a few users in the list
+      const users = await createUsers(4);
+      await Promise.all(users.map(createTestPlaylistItem));
+      for (const u of users) {
+        await uw.waitlist.addUser(u.id);
+      }
+
+      const token = await uw.test.createTestSessionToken(user);
+      await uw.acl.allow(user, ['user']);
+
+      const testSubject = await uw.test.createUser();
+      await createTestPlaylistItem(testSubject);
+
+      // Put the target user at the end of the list
+      await uw.waitlist.addUser(testSubject.id);
+
+      await uw.acl.createRole('mover', ['waitlist.move']);
+      await uw.acl.allow(user, ['mover']);
+
+      const res = await supertest(uw.server)
+        .get('/api/waitlist')
+        .expect(200);
+      assert.deepStrictEqual(res.body.data, [
+        users[1].id,
+        users[2].id,
+        users[3].id,
+        testSubject.id,
+      ]);
+
+      const movedRes = await supertest(uw.server)
+        .put('/api/waitlist/move')
+        .set('Cookie', `uwsession=${token}`)
+        .send({ userID: testSubject.id, position: 1 })
+        .expect(200);
+      assert.deepStrictEqual(movedRes.body.data, [
+        users[1].id,
+        testSubject.id,
+        users[2].id,
+        users[3].id,
+      ]);
+    });
+
+    it('moves user to a position past the end of the list', async () => {
+      // Put a few users in the list
+      const users = await createUsers(4);
+      await Promise.all(users.map(createTestPlaylistItem));
+      for (const u of users) {
+        await uw.waitlist.addUser(u.id);
+      }
+
+      const token = await uw.test.createTestSessionToken(user);
+      await uw.acl.allow(user, ['user']);
+
+      // This user will be at the top of the waitlist (users[0] is DJ).
+      const testSubject = users[1];
+
+      await uw.acl.createRole('mover', ['waitlist.move']);
+      await uw.acl.allow(user, ['mover']);
+
+      const res = await supertest(uw.server)
+        .get('/api/waitlist')
+        .expect(200);
+      assert.deepStrictEqual(res.body.data, [
+        users[1].id,
+        users[2].id,
+        users[3].id,
+      ]);
+
+      const movedRes = await supertest(uw.server)
+        .put('/api/waitlist/move')
+        .set('Cookie', `uwsession=${token}`)
+        .send({ userID: testSubject.id, position: 5 })
+        .expect(200);
+      assert.deepStrictEqual(movedRes.body.data, [
+        users[2].id,
+        users[3].id,
+        users[1].id,
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
Introduces a JSON key-value store API on top of SQLite.

**Todo**:
- [x] create the new table in a separate migration
- [x] add tests for `moveWaitlist`
- [x] some manual testing