### PR TITLE
Test endpoints for modifying user roles

### DIFF
--- a/locale/en.yaml
+++ b/locale/en.yaml
@@ -15,6 +15,7 @@ uwave:
     invalidResetToken: That reset token is invalid. Please double-check your reset token or request a new password reset.
     incorrectPassword: The password is incorrect.
     userNotFound: User not found.
+    roleNotFound: Role not found.
     playlistNotFound: Playlist not found.
     playlistItemNotFound: Playlist item not found.
     itemNotInPlaylist: Item not in playlist.

--- a/src/controllers/users.js
+++ b/src/controllers/users.js
@@ -97,9 +97,9 @@ async function addUserRole(req) {
   const { id, role } = req.params;
   const { acl, users } = req.uwave;
 
-  const selfHasRole = moderator.roles.includes('*') || moderator.roles.includes(role);
-  if (!selfHasRole) {
-    throw new PermissionError({ requiredRole: role });
+  const canModifyRoles = moderator.roles.includes('admin');
+  if (!canModifyRoles) {
+    throw new PermissionError({ requiredRole: 'admin' });
   }
 
   const user = await users.getUser(id);
@@ -128,9 +128,9 @@ async function removeUserRole(req) {
   const { id, role } = req.params;
   const { acl, users } = req.uwave;
 
-  const selfHasRole = moderator.roles.includes('*') || moderator.roles.includes(role);
-  if (!selfHasRole) {
-    throw new PermissionError({ requiredRole: role });
+  const canModifyRoles = moderator.roles.includes('admin');
+  if (!canModifyRoles) {
+    throw new PermissionError({ requiredRole: 'admin' });
   }
 
   const user = await users.getUser(id);

--- a/src/errors/index.js
+++ b/src/errors/index.js
@@ -187,6 +187,12 @@ const UserNotFoundError = createErrorClass('UserNotFoundError', {
   base: NotFound,
 });
 
+const RoleNotFoundError = createErrorClass('RoleNotFoundError', {
+  code: 'role-not-found',
+  string: 'errors.roleNotFound',
+  base: NotFound,
+});
+
 const PlaylistNotFoundError = createErrorClass('PlaylistNotFoundError', {
   code: 'playlist-not-found',
   string: 'errors.playlistNotFound',
@@ -288,6 +294,7 @@ export {
   ReCaptchaError,
   IncorrectPasswordError,
   UserNotFoundError,
+  RoleNotFoundError,
   PlaylistNotFoundError,
   PlaylistItemNotFoundError,
   HistoryEntryNotFoundError,

--- a/src/utils/sqlite.js
+++ b/src/utils/sqlite.js
@@ -188,3 +188,11 @@ export async function connect(path) {
   });
   return db;
 }
+
+/**
+ * @param {unknown} err
+ * @returns {err is (Error & { code: 'SQLITE_CONSTRAINT_FOREIGNKEY' })}
+ */
+export function isForeignKeyError(err) {
+  return err instanceof Error && 'code' in err && err.code === 'SQLITE_CONSTRAINT_FOREIGNKEY';
+}


### PR DESCRIPTION
This also restricts modifying roles to admin users for now, as the previous check didn't work after the SQLite migration, and was a bit too broad anyways.