### PR TITLE
Add tests for deleting chat messages, use HTTP endpoints for mute test

### DIFF
--- a/test/booth.mjs
+++ b/test/booth.mjs
@@ -5,6 +5,25 @@ import supertest from 'supertest';
 import createUwave from './utils/createUwave.mjs';
 import testSource from './utils/testSource.mjs';
 
+/** Retry the `fn` until it doesn't throw, or until the duration in milliseconds has elapsed. */
+async function retryFor(duration, fn) {
+  const end = Date.now() + duration;
+  let caughtError;
+  while (Date.now() < end) {
+    try {
+      const result = await fn();
+      return result;
+    } catch (err) {
+      caughtError = err;
+    }
+    await delay(10);
+  }
+
+  if (caughtError != null) {
+    throw new Error(`Failed after ${duration}ms`, { cause: caughtError });
+  }
+}
+
 describe('Booth', () => {
   describe('GET /booth', () => {
     let uw;
@@ -149,9 +168,10 @@ describe('Booth', () => {
         .set('Cookie', `uwsession=${token}`)
         .send({ direction: -1 })
         .expect(200);
-      await delay(200);
 
-      assert(receivedMessages.some((message) => message.command === 'vote' && message.data.value === -1));
+      await retryFor(500, () => {
+        assert(receivedMessages.some((message) => message.command === 'vote' && message.data.value === -1));
+      });
 
       // Resubmit vote without changing
       receivedMessages.length = 0;
@@ -160,8 +180,10 @@ describe('Booth', () => {
         .set('Cookie', `uwsession=${token}`)
         .send({ direction: -1 })
         .expect(200);
-      await delay(200);
 
+      // Need to just wait, as we can't assert for the absence of something happening
+      // without waiting the whole time limit
+      await delay(200);
       assert(
         !receivedMessages.some((message) => message.command === 'vote' && message.data.value === -1),
         'should not have re-emitted the vote',
@@ -172,9 +194,10 @@ describe('Booth', () => {
         .set('Cookie', `uwsession=${token}`)
         .send({ direction: 1 })
         .expect(200);
-      await delay(200);
 
-      assert(receivedMessages.some((message) => message.command === 'vote' && message.data.value === 1));
+      await retryFor(500, () => {
+        assert(receivedMessages.some((message) => message.command === 'vote' && message.data.value === 1));
+      });
 
       djWs.close();
     });

--- a/test/booth.mjs
+++ b/test/booth.mjs
@@ -4,25 +4,7 @@ import delay from 'delay';
 import supertest from 'supertest';
 import createUwave from './utils/createUwave.mjs';
 import testSource from './utils/testSource.mjs';
-
-/** Retry the `fn` until it doesn't throw, or until the duration in milliseconds has elapsed. */
-async function retryFor(duration, fn) {
-  const end = Date.now() + duration;
-  let caughtError;
-  while (Date.now() < end) {
-    try {
-      const result = await fn();
-      return result;
-    } catch (err) {
-      caughtError = err;
-    }
-    await delay(10);
-  }
-
-  if (caughtError != null) {
-    throw new Error(`Failed after ${duration}ms`, { cause: caughtError });
-  }
-}
+import { retryFor } from './utils/retry.mjs';
 
 describe('Booth', () => {
   describe('GET /booth', () => {

--- a/test/chat.mjs
+++ b/test/chat.mjs
@@ -1,8 +1,8 @@
 import assert from 'assert';
 import * as sinon from 'sinon';
+import supertest from 'supertest';
 import delay from 'delay';
 import createUwave from './utils/createUwave.mjs';
-import supertest from 'supertest';
 
 const sandbox = sinon.createSandbox();
 

--- a/test/chat.mjs
+++ b/test/chat.mjs
@@ -6,6 +6,7 @@ import createUwave from './utils/createUwave.mjs';
 
 const sandbox = sinon.createSandbox();
 
+/** Retry the `fn` until it doesn't throw, or until the duration in milliseconds has elapsed. */
 async function retryFor(duration, fn) {
   const end = Date.now() + duration;
   let caughtError;
@@ -16,7 +17,7 @@ async function retryFor(duration, fn) {
     } catch (err) {
       caughtError = err;
     }
-    await delay(100);
+    await delay(10);
   }
 
   if (caughtError != null) {

--- a/test/chat.mjs
+++ b/test/chat.mjs
@@ -2,29 +2,10 @@ import { randomUUID } from 'crypto';
 import assert from 'assert';
 import * as sinon from 'sinon';
 import supertest from 'supertest';
-import delay from 'delay';
 import createUwave from './utils/createUwave.mjs';
+import { retryFor } from './utils/retry.mjs';
 
 const sandbox = sinon.createSandbox();
-
-/** Retry the `fn` until it doesn't throw, or until the duration in milliseconds has elapsed. */
-async function retryFor(duration, fn) {
-  const end = Date.now() + duration;
-  let caughtError;
-  while (Date.now() < end) {
-    try {
-      const result = await fn();
-      return result;
-    } catch (err) {
-      caughtError = err;
-    }
-    await delay(10);
-  }
-
-  if (caughtError != null) {
-    throw new Error(`Failed after ${duration}ms`, { cause: caughtError });
-  }
-}
 
 describe('Chat', () => {
   let uw;

--- a/test/utils/retry.mjs
+++ b/test/utils/retry.mjs
@@ -1,0 +1,20 @@
+import delay from 'delay';
+
+/** Retry the `fn` until it doesn't throw, or until the duration in milliseconds has elapsed. */
+export async function retryFor(duration, fn) {
+  const end = Date.now() + duration;
+  let caughtError;
+  while (Date.now() < end) {
+    try {
+      const result = await fn();
+      return result;
+    } catch (err) {
+      caughtError = err;
+    }
+    await delay(10);
+  }
+
+  if (caughtError != null) {
+    throw new Error(`Failed after ${duration}ms`, { cause: caughtError });
+  }
+}


### PR DESCRIPTION
Instead of mocking `isMuted`

Increases test coverage.
The `retryFor` helper makes this run a bit faster typically.