### PR TITLE
Remove remnants of replace booth

### DIFF
--- a/src/controllers/booth.js
+++ b/src/controllers/booth.js
@@ -175,40 +175,6 @@ async function leaveBooth(req) {
 }
 
 /**
- * @typedef {object} ReplaceBoothBody
- * @prop {UserID} userID
- */
-
-/**
- * @type {import('../types.js').AuthenticatedController<{}, {}, ReplaceBoothBody>}
- */
-async function replaceBooth(req) {
-  const uw = req.uwave;
-  const moderatorID = req.user.id;
-  const { userID } = req.body;
-  let waitlist = await uw.redis.lrange('waitlist', 0, -1);
-
-  if (!waitlist.length) {
-    throw new HTTPError(404, 'Waitlist is empty.');
-  }
-
-  if (waitlist.includes(userID)) {
-    uw.redis.lrem('waitlist', 1, userID);
-    await uw.redis.lpush('waitlist', userID);
-    waitlist = await uw.redis.lrange('waitlist', 0, -1);
-  }
-
-  uw.publish('booth:replace', {
-    moderatorID,
-    userID,
-  });
-
-  await uw.booth.advance();
-
-  return toItemResponse({});
-}
-
-/**
  * @param {import('../Uwave.js').default} uw
  * @param {HistoryEntryID} historyEntryID
  * @param {UserID} userID
@@ -428,7 +394,6 @@ export {
   getHistory,
   getVote,
   leaveBooth,
-  replaceBooth,
   skipBooth,
   socketVote,
   vote,

--- a/src/redisMessages.ts
+++ b/src/redisMessages.ts
@@ -27,10 +27,6 @@ export type ServerActionParameters = {
     moderatorID: UserID | null,
     reason: string | null,
   },
-  'booth:replace': {
-    userID: UserID,
-    moderatorID: UserID | null,
-  },
 
   'chat:message': {
     id: string,

--- a/src/validations.js
+++ b/src/validations.js
@@ -148,16 +148,6 @@ export const leaveBooth = /** @type {const} */ ({
   },
 });
 
-export const replaceBooth = /** @type {const} */ ({
-  body: {
-    type: 'object',
-    properties: {
-      userID: { $ref: 'https://ns.u-wave.net/schemas/definitions.json#/definitions/UUID' },
-    },
-    required: ['userID'],
-  },
-});
-
 export const getVote = /** @type {const} */ ({
   params: {
     type: 'object',


### PR DESCRIPTION
This was probably a nice idea we had back when üWave was first started. A moderator would be able to instantly put a user in the booth, skipping the waitlist.

In practice we never implemented it, and it would require client-side support. I doubt it's all that useful and it is just dead code right now.