### PR TITLE
Typed representation of serialized SQLite JSON/JSONB

### DIFF
--- a/src/plugins/users.js
+++ b/src/plugins/users.js
@@ -7,7 +7,7 @@ import Page from '../Page.js';
 import {
   IncorrectPasswordError, UsedEmailError, UsedUsernameError, UserNotFoundError,
 } from '../errors/index.js';
-import { jsonGroupArray } from '../utils/sqlite.js';
+import { fromJson, jsonGroupArray } from '../utils/sqlite.js';
 
 const { pick, omit } = lodash;
 
@@ -156,14 +156,10 @@ class UsersRepository {
       ])
       .execute();
 
-    for (const user of users) {
-      const roles = /** @type {string[]} */ (JSON.parse(
-        /** @type {string} */ (/** @type {unknown} */ (user.roles)),
-      ));
-      Object.assign(user, { roles });
-    }
-
-    return /** @type {import('type-fest').SetNonNullable<(typeof users)[0], 'roles'>[]} */ (users);
+    return users.map((user) => ({
+      ...user,
+      roles: user.roles != null ? fromJson(user.roles) : [],
+    }));
   }
 
   /**

--- a/src/utils/serialize.js
+++ b/src/utils/serialize.js
@@ -40,7 +40,7 @@ export function serializeMedia(model) {
 /**
  * @param {{
  *   id: import('../schema.js').PlaylistItemID,
- *   media: import('../schema.js').Media,
+ *   media: Parameters<typeof serializeMedia>[0],
  *   artist: string,
  *   title: string,
  *   start: number,


### PR DESCRIPTION
Ref #659

Better enforces the difference between a column that is `NULL` or a column that contains JSON containing `null`, and removes the need for unsafe manual casting.