### PR TITLE
Make the migration script more robust

### DIFF
--- a/bin/u-wave-core.js
+++ b/bin/u-wave-core.js
@@ -37,6 +37,10 @@ const envSchema = {
       type: 'number',
       default: 6042,
     },
+    MONGODB_URL: {
+      type: 'string',
+      format: 'uri',
+    },
     REDIS_URL: {
       type: 'string',
       format: 'uri',
@@ -108,6 +112,8 @@ const uw = uwave({
   redis: config.REDIS_URL,
   sqlite: config.SQLITE_PATH,
   secret,
+  // This property is untyped, it is propagated to the also-untyped MongoDB -> SQL migration
+  mongo: config.MONGODB_URL,
 });
 
 uw.on('redisError', (err) => {

--- a/src/migrations/003-populate-sql.cjs
+++ b/src/migrations/003-populate-sql.cjs
@@ -419,7 +419,7 @@ function zip(a, b) {
       const itemB = iterB.next();
 
       if (itemA.done !== itemB.done) {
-        throw new Error('zip: iterators have different lengths')
+        throw new Error('zip: iterators have different lengths');
       }
 
       return {

--- a/src/migrations/003-populate-sql.cjs
+++ b/src/migrations/003-populate-sql.cjs
@@ -560,6 +560,16 @@ async function up({ context: uw }) {
           .set({ items: jsonb(items) })
           .execute();
       }
+
+      if (user.activePlaylist != null) {
+        const activePlaylistID = playlistIDs.get(user.activePlaylist.toString());
+        if (activePlaylistID != null) {
+          await tx.updateTable('users')
+            .where('id', '=', userID)
+            .set({ activePlaylistID })
+            .execute();
+        }
+      }
     }
 
     for await (const entry of models.Authentication.find().lean()) {


### PR DESCRIPTION
MongoDB is schema-less, so it can contain arbitrary stuff in theory. After the first few months we've been quite diligent about keeping models compatible, but for WLK, there's some very old data in MongoDB that doesn't quite follow the current schema.

This patches the migration script to support that sort of bad data, including:
- Duplicate entries for the same media
- Missing `createdAt` and `updatedAt` timestamps (defaulted to the current date)
- Missing `end` property for playlist item (only one case, defaulting to 0)

Migration took about 2 minutes to run on my machine. Not ideal, but fine, I think. If there's even any other servers out there today they won't have nearly as much data as WLK does.