### PR TITLE
Only log server errors at the error level

### DIFF
--- a/src/HttpApi.js
+++ b/src/HttpApi.js
@@ -176,6 +176,10 @@ async function errorHandling(uw) {
   uw.logger.debug({ ns: 'uwave:http-api' }, 'setup HTTP error handling');
   uw.httpApi.use(errorHandler({
     onError(_req, error) {
+      if ('status' in error && typeof error.status === 'number' && error.status >= 400 && error.status < 500) {
+        return;
+      }
+
       uw.logger.error({ err: error, ns: 'uwave:http-api' });
     },
   }));

--- a/src/errors/ValidationError.js
+++ b/src/errors/ValidationError.js
@@ -12,6 +12,7 @@ class ValidationError extends UwaveError {
     this.expose = true;
     this.name = 'ValidationError';
     this.code = 'SCHEMA_VALIDATION_FAILED';
+    this.status = 400;
 
     this.errors = errors;
   }

--- a/test/utils/createUwave.mjs
+++ b/test/utils/createUwave.mjs
@@ -71,7 +71,7 @@ async function createUwave(name, options) {
     sqlite: ':memory:',
     secret: Buffer.from(`secret_${name}`),
     logger: {
-      level: 'silent',
+      level: 'error',
     },
   });
 


### PR DESCRIPTION
Error logs mostly consisted of 4xx errors, which are expected in normal operation. 4xx errors are now not logged, but the response will be logged by pino-http.