### PR TITLE
Improve session handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "bcryptjs": "^2.4.3",
     "better-sqlite3": "^11.2.1",
     "body-parser": "^1.19.0",
+    "connect-redis": "^8.0.1",
     "cookie": "^1.0.1",
     "cookie-parser": "^1.4.4",
     "cors": "^2.8.5",

--- a/src/HttpApi.js
+++ b/src/HttpApi.js
@@ -7,6 +7,7 @@ import cookieParser from 'cookie-parser';
 import cors from 'cors';
 import helmet from 'helmet';
 import session from 'express-session';
+import { RedisStore } from 'connect-redis';
 import qs from 'qs';
 import { pinoHttp } from 'pino-http';
 
@@ -122,44 +123,9 @@ async function httpApi(uw, options) {
         secure: uw.express.get('env') === 'production',
         httpOnly: true,
       },
-      store: new class extends session.Store {
-        /**
-         * @param {string} sid
-         * @param {(err?: Error, data?: session.SessionData | null) => void} callback
-         */
-        get(sid, callback) {
-          uw.redis.get(`session:${sid}`).then((data) => {
-            callback(undefined, data == null ? null : JSON.parse(data));
-          }, (err) => {
-            callback(err);
-          });
-        }
-
-        /**
-         * @param {string} sid
-         * @param {session.SessionData} data
-         * @param {(err?: Error) => void} callback
-         */
-        set(sid, data, callback) {
-          uw.redis.set(`session:${sid}`, JSON.stringify(data)).then(() => {
-            callback();
-          }, (err) => {
-            callback(err);
-          });
-        }
-
-        /**
-         * @param {string} sid
-         * @param {(err?: Error) => void} callback
-         */
-        destroy(sid, callback) {
-          uw.redis.del(`session:${sid}`).then(() => {
-            callback();
-          }, (err) => {
-            callback(err);
-          });
-        }
-      }(),
+      store: new RedisStore({
+        client: uw.redis,
+      }),
     }))
     .use(uw.passport.initialize())
     .use(addFullUrl())

--- a/src/HttpApi.js
+++ b/src/HttpApi.js
@@ -164,7 +164,7 @@ async function httpApi(uw, options) {
     .use(uw.passport.initialize())
     .use(addFullUrl())
     .use(attachUwaveMeta(uw.httpApi, uw))
-    .use(uw.passport.authenticate('jwt'))
+    .use(uw.passport.authenticate('jwt', { session: false }))
     .use(uw.passport.session())
     .use(rateLimit('api-http', { max: 500, duration: 60 * 1000 }));
 

--- a/src/HttpApi.js
+++ b/src/HttpApi.js
@@ -86,6 +86,7 @@ async function httpApi(uw, options) {
 
   const logger = uw.logger.child({
     ns: 'uwave:http-api',
+    level: 'warn',
   });
 
   uw.config.register(optionsSchema['uw:key'], optionsSchema);

--- a/src/HttpApi.js
+++ b/src/HttpApi.js
@@ -164,6 +164,7 @@ async function httpApi(uw, options) {
     .use(uw.passport.initialize())
     .use(addFullUrl())
     .use(attachUwaveMeta(uw.httpApi, uw))
+    .use(uw.passport.authenticate('jwt'))
     .use(uw.passport.session())
     .use(rateLimit('api-http', { max: 500, duration: 60 * 1000 }));
 

--- a/src/HttpApi.js
+++ b/src/HttpApi.js
@@ -127,12 +127,12 @@ async function httpApi(uw, options) {
          * @param {string} sid
          * @param {(err?: Error, data?: session.SessionData | null) => void} callback
          */
-        get (sid, callback) {
+        get(sid, callback) {
           uw.redis.get(`session:${sid}`).then((data) => {
             callback(undefined, data == null ? null : JSON.parse(data));
           }, (err) => {
             callback(err);
-          })
+          });
         }
 
         /**
@@ -145,7 +145,7 @@ async function httpApi(uw, options) {
             callback();
           }, (err) => {
             callback(err);
-          })
+          });
         }
 
         /**
@@ -157,9 +157,9 @@ async function httpApi(uw, options) {
             callback();
           }, (err) => {
             callback(err);
-          })
+          });
         }
-      },
+      }(),
     }))
     .use(uw.passport.initialize())
     .use(addFullUrl())

--- a/src/SocketServer.js
+++ b/src/SocketServer.js
@@ -455,7 +455,9 @@ class SocketServer {
    */
   async initLostConnections() {
     const { db, redis } = this.#uw;
-    const userIDs = /** @type {import('./schema').UserID[]} */ (await redis.lrange(REDIS_ACTIVE_SESSIONS, 0, -1));
+    const userIDs = /** @type {import('./schema').UserID[]} */ (
+      await redis.lrange(REDIS_ACTIVE_SESSIONS, 0, -1)
+    );
     const disconnectedIDs = userIDs.filter((userID) => !this.connection(userID));
 
     if (disconnectedIDs.length === 0) {

--- a/src/SocketServer.js
+++ b/src/SocketServer.js
@@ -15,6 +15,8 @@ import { serializeUser } from './utils/serialize.js';
 
 const { debounce, isEmpty } = lodash;
 
+export const REDIS_ACTIVE_SESSIONS = 'users';
+
 /**
  * @typedef {import('./schema.js').User} User
  */
@@ -76,7 +78,7 @@ class SocketServer {
         // We do need to clear the `users` list because the lost connection handlers
         // will not do so.
         uw.socketServer.#logger.warn({ err }, 'could not initialise lost connections');
-        await uw.redis.del('users');
+        await uw.redis.del(REDIS_ACTIVE_SESSIONS);
       }
     });
 
@@ -394,7 +396,7 @@ class SocketServer {
         const user = await users.getUser(userID);
         if (user) {
           // TODO this should not be the socket server code's responsibility
-          await redis.rpush('users', user.id);
+          await redis.rpush(REDIS_ACTIVE_SESSIONS, user.id);
           this.broadcast('join', serializeUser(user));
         }
       },
@@ -453,7 +455,7 @@ class SocketServer {
    */
   async initLostConnections() {
     const { db, redis } = this.#uw;
-    const userIDs = /** @type {import('./schema').UserID[]} */ (await redis.lrange('users', 0, -1));
+    const userIDs = /** @type {import('./schema').UserID[]} */ (await redis.lrange(REDIS_ACTIVE_SESSIONS, 0, -1));
     const disconnectedIDs = userIDs.filter((userID) => !this.connection(userID));
 
     if (disconnectedIDs.length === 0) {
@@ -465,7 +467,7 @@ class SocketServer {
       .selectAll()
       .execute();
     disconnectedUsers.forEach((user) => {
-      this.add(this.createLostConnection(user));
+      this.add(this.createLostConnection(user, 'TODO: Actual session ID!!'));
     });
   }
 
@@ -529,15 +531,15 @@ class SocketServer {
     connection.on('close', () => {
       this.remove(connection);
     });
-    connection.on('authenticate', async (user) => {
-      const isReconnect = await connection.isReconnect(user);
+    connection.on('authenticate', async (user, sessionID) => {
+      const isReconnect = await connection.isReconnect(sessionID);
       this.#logger.info({ userId: user.id, isReconnect }, 'authenticated socket');
       if (isReconnect) {
-        const previousConnection = this.getLostConnection(user);
+        const previousConnection = this.getLostConnection(sessionID);
         if (previousConnection) this.remove(previousConnection);
       }
 
-      this.replace(connection, this.createAuthedConnection(socket, user));
+      this.replace(connection, this.createAuthedConnection(socket, user, sessionID));
 
       if (!isReconnect) {
         this.#uw.publish('user:join', { userID: user.id });
@@ -551,18 +553,19 @@ class SocketServer {
    *
    * @param {import('ws').WebSocket} socket
    * @param {User} user
+   * @param {string} sessionID
    * @returns {AuthedConnection}
    * @private
    */
-  createAuthedConnection(socket, user) {
-    const connection = new AuthedConnection(this.#uw, socket, user);
+  createAuthedConnection(socket, user, sessionID) {
+    const connection = new AuthedConnection(this.#uw, socket, user, sessionID);
     connection.on('close', ({ banned }) => {
       if (banned) {
         this.#logger.info({ userId: user.id }, 'removing connection after ban');
         disconnectUser(this.#uw, user.id);
       } else if (!this.#closing) {
         this.#logger.info({ userId: user.id }, 'lost connection');
-        this.add(this.createLostConnection(user));
+        this.add(this.createLostConnection(user, sessionID));
       }
       this.remove(connection);
     });
@@ -594,11 +597,12 @@ class SocketServer {
    * Create a connection instance for a user who disconnected.
    *
    * @param {User} user
+   * @param {string} sessionID
    * @returns {LostConnection}
    * @private
    */
-  createLostConnection(user) {
-    const connection = new LostConnection(this.#uw, user, this.options.timeout);
+  createLostConnection(user, sessionID) {
+    const connection = new LostConnection(this.#uw, user, sessionID, this.options.timeout);
     connection.on('close', () => {
       this.#logger.info({ userId: user.id }, 'user left');
       this.remove(connection);
@@ -618,8 +622,9 @@ class SocketServer {
    * @private
    */
   add(connection) {
-    const userId = 'user' in connection ? connection.user.id : null;
-    this.#logger.trace({ type: connection.constructor.name, userId }, 'add connection');
+    const userID = 'user' in connection ? connection.user.id : null;
+    const sessionID = 'sessionID' in connection ? connection.sessionID : null;
+    this.#logger.trace({ type: connection.constructor.name, userID, sessionID }, 'add connection');
 
     this.#connections.push(connection);
     this.#recountGuests();
@@ -632,8 +637,9 @@ class SocketServer {
    * @private
    */
   remove(connection) {
-    const userId = 'user' in connection ? connection.user.id : null;
-    this.#logger.trace({ type: connection.constructor.name, userId }, 'remove connection');
+    const userID = 'user' in connection ? connection.user.id : null;
+    const sessionID = 'sessionID' in connection ? connection.sessionID : null;
+    this.#logger.trace({ type: connection.constructor.name, userID, sessionID }, 'remove connection');
 
     const i = this.#connections.indexOf(connection);
     this.#connections.splice(i, 1);

--- a/src/auth/JWTStrategy.js
+++ b/src/auth/JWTStrategy.js
@@ -110,7 +110,11 @@ class JWTStrategy extends Strategy {
       throw new BannedError();
     }
 
-    return this.success(user);
+    const info = 'sessionID' in value && typeof value.sessionID === 'string'
+      ? { sessionID: value.sessionID }
+      : undefined;
+
+    return this.success(user, info);
   }
 }
 

--- a/src/controllers/authenticate.js
+++ b/src/controllers/authenticate.js
@@ -3,7 +3,6 @@ import cookie from 'cookie';
 import jwt from 'jsonwebtoken';
 import randomString from 'random-string';
 import nodeFetch from 'node-fetch';
-import ms from 'ms';
 import htmlescape from 'htmlescape';
 import httpErrors from 'http-errors';
 import nodemailer from 'nodemailer';
@@ -36,13 +35,6 @@ const { BadRequest } = httpErrors;
  * @typedef {object} WithAuthOptions
  * @prop {AuthenticateOptions} authOptions
  */
-
-/**
- * @param {string} str
- */
-function seconds(str) {
-  return Math.floor(ms(str) / 1000);
-}
 
 /**
  * @type {import('../types.js').Controller}

--- a/src/controllers/users.js
+++ b/src/controllers/users.js
@@ -10,6 +10,7 @@ import toItemResponse from '../utils/toItemResponse.js';
 import toListResponse from '../utils/toListResponse.js';
 import toPaginatedResponse from '../utils/toPaginatedResponse.js';
 import { muteUser, unmuteUser } from './chat.js';
+import { REDIS_ACTIVE_SESSIONS } from '../SocketServer.js';
 
 /**
  * @typedef {import('../schema').UserID} UserID
@@ -200,7 +201,7 @@ async function disconnectUser(uw, userID) {
     }
   }
 
-  await uw.redis.lrem('users', 0, userID);
+  await uw.redis.lrem(REDIS_ACTIVE_SESSIONS, 0, userID);
 
   uw.publish('user:leave', { userID });
 }

--- a/src/middleware/requireActiveConnection.js
+++ b/src/middleware/requireActiveConnection.js
@@ -1,5 +1,6 @@
 import httpErrors from 'http-errors';
 import wrapMiddleware from '../utils/wrapMiddleware.js';
+import { REDIS_ACTIVE_SESSIONS } from '../SocketServer.js';
 
 const { BadRequest } = httpErrors;
 
@@ -9,7 +10,7 @@ function requireActiveConnection() {
    * @param {import('../schema.js').User} user
    */
   async function isConnected(uwave, user) {
-    const onlineIDs = await uwave.redis.lrange('users', 0, -1);
+    const onlineIDs = await uwave.redis.lrange(REDIS_ACTIVE_SESSIONS, 0, -1);
     return onlineIDs.indexOf(user.id) !== -1;
   }
 

--- a/src/sockets/AuthedConnection.js
+++ b/src/sockets/AuthedConnection.js
@@ -19,7 +19,9 @@ class AuthedConnection extends EventEmitter {
     this.events = new Ultron(this.socket);
     this.user = user;
     this.sessionID = sessionID;
-    this.#logger = uw.logger.child({ ns: 'uwave:sockets', connectionType: 'AuthedConnection', userId: this.user.id, sessionID });
+    this.#logger = uw.logger.child({
+      ns: 'uwave:sockets', connectionType: 'AuthedConnection', userId: this.user.id, sessionID,
+    });
 
     this.events.on('close', () => {
       this.emit('close', { banned: this.banned });

--- a/src/sockets/AuthedConnection.js
+++ b/src/sockets/AuthedConnection.js
@@ -10,14 +10,16 @@ class AuthedConnection extends EventEmitter {
    * @param {import('../Uwave.js').default} uw
    * @param {import('ws').WebSocket} socket
    * @param {import('../schema.js').User} user
+   * @param {string} sessionID
    */
-  constructor(uw, socket, user) {
+  constructor(uw, socket, user, sessionID) {
     super();
     this.uw = uw;
     this.socket = socket;
     this.events = new Ultron(this.socket);
     this.user = user;
-    this.#logger = uw.logger.child({ ns: 'uwave:sockets', connectionType: 'AuthedConnection', userId: this.user.id });
+    this.sessionID = sessionID;
+    this.#logger = uw.logger.child({ ns: 'uwave:sockets', connectionType: 'AuthedConnection', userId: this.user.id, sessionID });
 
     this.events.on('close', () => {
       this.emit('close', { banned: this.banned });
@@ -32,14 +34,14 @@ class AuthedConnection extends EventEmitter {
    * @private
    */
   get key() {
-    return `http-api:disconnected:${this.user.id}`;
+    return `http-api:disconnected:${this.sessionID}`;
   }
 
   /**
    * @private
    */
   get messagesKey() {
-    return `http-api:disconnected:${this.user.id}:messages`;
+    return `http-api:disconnected:${this.sessionID}:messages`;
   }
 
   /**

--- a/src/sockets/GuestConnection.js
+++ b/src/sockets/GuestConnection.js
@@ -41,8 +41,8 @@ class GuestConnection extends EventEmitter {
     const { bans, users } = this.uw;
     const { authRegistry } = this.options;
 
-    const userID = await authRegistry.getTokenUser(token);
-    if (!userID || typeof userID !== 'string') {
+    const { userID, sessionID } = await authRegistry.getTokenUser(token);
+    if (!sessionID || typeof sessionID !== 'string') {
       throw new Error('Invalid token');
     }
     const userModel = await users.getUser(userID);
@@ -57,14 +57,14 @@ class GuestConnection extends EventEmitter {
       throw new Error('You have been banned');
     }
 
-    this.emit('authenticate', userModel);
+    this.emit('authenticate', userModel, sessionID);
   }
 
   /**
-   * @param {import('../schema.js').User} user
+   * @param {string} sessionID
    */
-  isReconnect(user) {
-    return this.uw.redis.exists(`http-api:disconnected:${user.id}`);
+  isReconnect(sessionID) {
+    return this.uw.redis.exists(`http-api:disconnected:${sessionID}`);
   }
 
   /**

--- a/src/sockets/LostConnection.js
+++ b/src/sockets/LostConnection.js
@@ -14,7 +14,9 @@ class LostConnection extends EventEmitter {
     this.user = user;
     this.sessionID = sessionID;
     this.timeout = timeout;
-    this.#logger = uw.logger.child({ ns: 'uwave:sockets', connectionType: 'LostConnection', userID: this.user.id, sessionID });
+    this.#logger = uw.logger.child({
+      ns: 'uwave:sockets', connectionType: 'LostConnection', userID: this.user.id, sessionID,
+    });
 
     this.initQueued();
     this.setTimeout(timeout);

--- a/src/sockets/LostConnection.js
+++ b/src/sockets/LostConnection.js
@@ -6,13 +6,15 @@ class LostConnection extends EventEmitter {
   /**
    * @param {import('../Uwave.js').default} uw
    * @param {import('../schema.js').User} user
+   * @param {string} sessionID
    */
-  constructor(uw, user, timeout = 30) {
+  constructor(uw, user, sessionID, timeout = 30) {
     super();
     this.uw = uw;
     this.user = user;
+    this.sessionID = sessionID;
     this.timeout = timeout;
-    this.#logger = uw.logger.child({ ns: 'uwave:sockets', connectionType: 'LostConnection', userId: this.user.id });
+    this.#logger = uw.logger.child({ ns: 'uwave:sockets', connectionType: 'LostConnection', userID: this.user.id, sessionID });
 
     this.initQueued();
     this.setTimeout(timeout);
@@ -22,14 +24,14 @@ class LostConnection extends EventEmitter {
    * @private
    */
   get key() {
-    return `http-api:disconnected:${this.user.id}`;
+    return `http-api:disconnected:${this.sessionID}`;
   }
 
   /**
    * @private
    */
   get messagesKey() {
-    return `http-api:disconnected:${this.user.id}:messages`;
+    return `http-api:disconnected:${this.sessionID}:messages`;
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,10 @@ declare global {
       authOptions?: AuthenticateOptions;
       fullUrl: string;
     }
+    interface AuthInfo {
+      /** A session ID provided through some other means than the actual session. */
+      sessionID?: string;
+    }
   }
 }
 

--- a/test/sockets.mjs
+++ b/test/sockets.mjs
@@ -1,0 +1,75 @@
+import { randomUUID } from 'node:crypto';
+import { once } from 'node:events';
+import * as sinon from 'sinon';
+import createUwave from './utils/createUwave.mjs';
+import { retryFor } from './utils/retry.mjs';
+
+describe('Sockets', () => {
+  let uw;
+
+  beforeEach(async () => {
+    uw = await createUwave('sockets');
+  });
+  afterEach(async () => {
+    await uw.destroy();
+  });
+
+  it('keeps messages in queue', async () => {
+    const user = await uw.test.createUser();
+    // TODO: Manually providing session ID here partially defeats the purpose of the test.
+    // The websocket connection should instead mimick the "normal" way of connecting,
+    // with a server-generated auth token
+    const userSession = randomUUID();
+    const chatter = await uw.test.createUser();
+
+    const ws = await uw.test.connectToWebSocketAs(user, userSession);
+    const wsChatter = await uw.test.connectToWebSocketAs(chatter);
+
+    const receivedMessages = [];
+    ws.on('message', (data) => {
+      receivedMessages.push(JSON.parse(data));
+    });
+
+    wsChatter.send(JSON.stringify({ command: 'sendChat', data: 'a' }));
+    wsChatter.send(JSON.stringify({ command: 'sendChat', data: 'b' }));
+
+    await retryFor(1500, () => {
+      sinon.assert.match(receivedMessages, sinon.match.some(sinon.match({
+        command: 'chatMessage',
+        data: { userID: chatter.id, message: 'a' },
+      })));
+      sinon.assert.match(receivedMessages, sinon.match.some(sinon.match({
+        command: 'chatMessage',
+        data: { userID: chatter.id, message: 'b' },
+      })));
+    });
+
+    // Lose the connection
+    ws.close();
+    await once(ws, 'close');
+
+    wsChatter.send(JSON.stringify({ command: 'sendChat', data: 'c' }));
+    wsChatter.send(JSON.stringify({ command: 'sendChat', data: 'd' }));
+    wsChatter.close();
+    await once(wsChatter, 'close');
+
+    // Reconnect & receive the messages
+    const ws2 = await uw.test.connectToWebSocketAs(user, userSession);
+    ws2.on('message', (data) => {
+      receivedMessages.push(JSON.parse(data));
+    });
+
+    await retryFor(1500, () => {
+      sinon.assert.match(receivedMessages, sinon.match.some(sinon.match({
+        command: 'chatMessage',
+        data: { userID: chatter.id, message: 'c' },
+      })));
+      sinon.assert.match(receivedMessages, sinon.match.some(sinon.match({
+        command: 'chatMessage',
+        data: { userID: chatter.id, message: 'd' },
+      })));
+    });
+
+    ws2.close();
+  });
+});

--- a/test/utils/plugin.mjs
+++ b/test/utils/plugin.mjs
@@ -20,9 +20,10 @@ async function testPlugin(uw) {
       .executeTakeFirstOrThrow();
   }
 
-  async function connectToWebSocketAs(user) {
+  async function connectToWebSocketAs(user, session) {
     const { port } = uw.server.address();
-    const token = await uw.socketServer.authRegistry.createAuthToken(user);
+
+    const token = await uw.socketServer.authRegistry.createAuthToken(user, session ?? randomUUID());
 
     const ws = new WebSocket(`ws://localhost:${port}`);
     await events.once(ws, 'open');

--- a/test/utils/plugin.mjs
+++ b/test/utils/plugin.mjs
@@ -43,7 +43,7 @@ async function testPlugin(uw) {
 
   async function createTestSessionToken(user) {
     const token = jwt.sign(
-      { id: user.id },
+      { id: user.id, sessionID: randomUUID() },
       uw.options.secret,
       { expiresIn: '1d' },
     );


### PR DESCRIPTION
Closes #671 

Todos:
- [x] Remove `uwsession` (/ change the value to express-session's `connect.sid`)
- [x] JWT auth should probably not use `passport.authenticate()`, as it creates a new session every request
- [ ] Test propagating missing messages for lost connection