### PR TITLE
ci: only run CI on default branch & PRs targeting default branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+    branches: [default]
+  push:
+    branches: [default]
 
 jobs:
   lint:


### PR DESCRIPTION
Especially prevents duplicate runs on PRs from repo-local branches