### PR TITLE
Fix type checking of CommonJS module imports

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "strict": true,
     "module": "es2022",
     "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
     "useUnknownInCatchVariables": false,
     "allowJs": true,
     "checkJs": true,


### PR DESCRIPTION
Not sure why it used to work but now it doesn't, and it makes sense that
it doesn't. Default import syntax on CommonJS modules should use a
synthetic default import.
