### PR TITLE
Store express-session state in SQLite

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "bcryptjs": "^3.0.1",
     "better-sqlite3": "^12.1.0",
     "body-parser": "^2.2.0",
-    "connect-redis": "^8.0.1",
     "cookie": "^1.0.1",
     "cookie-parser": "^1.4.4",
     "cors": "^2.8.5",

--- a/src/HttpApi.js
+++ b/src/HttpApi.js
@@ -9,6 +9,7 @@ import helmet from 'helmet';
 import session from 'express-session';
 import qs from 'qs';
 import { pinoHttp } from 'pino-http';
+import { milliseconds } from 'date-fns';
 
 // routes
 import authenticate from './routes/authenticate.js';
@@ -29,6 +30,8 @@ import errorHandler from './middleware/errorHandler.js';
 import AuthRegistry from './AuthRegistry.js';
 import matchOrigin from './utils/matchOrigin.js';
 import SqliteSessionStore from './utils/SqliteSessionStore.js';
+
+const SESSION_DURATION = milliseconds({ days: 7 });
 
 const optionsSchema = JSON.parse(
   fs.readFileSync(new URL('./schemas/httpApi.json', import.meta.url), 'utf8'),
@@ -123,9 +126,11 @@ async function httpApi(uw, options) {
       secret: options.secret,
       resave: false,
       saveUninitialized: false,
+      rolling: true,
       cookie: {
         secure: uw.express.get('env') === 'production',
         httpOnly: true,
+        maxAge: SESSION_DURATION,
       },
       store: new SqliteSessionStore(uw.db, uw.logger.child({ ns: 'uwave:sessions' })),
     }))

--- a/src/HttpApi.js
+++ b/src/HttpApi.js
@@ -7,7 +7,6 @@ import cookieParser from 'cookie-parser';
 import cors from 'cors';
 import helmet from 'helmet';
 import session from 'express-session';
-import { RedisStore } from 'connect-redis';
 import qs from 'qs';
 import { pinoHttp } from 'pino-http';
 
@@ -29,6 +28,7 @@ import errorHandler from './middleware/errorHandler.js';
 // utils
 import AuthRegistry from './AuthRegistry.js';
 import matchOrigin from './utils/matchOrigin.js';
+import SqliteSessionStore from './utils/SqliteSessionStore.js';
 
 const optionsSchema = JSON.parse(
   fs.readFileSync(new URL('./schemas/httpApi.json', import.meta.url), 'utf8'),
@@ -127,9 +127,7 @@ async function httpApi(uw, options) {
         secure: uw.express.get('env') === 'production',
         httpOnly: true,
       },
-      store: new RedisStore({
-        client: uw.redis,
-      }),
+      store: new SqliteSessionStore(uw.db),
     }))
     .use(uw.passport.initialize())
     .use(addFullUrl())

--- a/src/HttpApi.js
+++ b/src/HttpApi.js
@@ -127,7 +127,7 @@ async function httpApi(uw, options) {
         secure: uw.express.get('env') === 'production',
         httpOnly: true,
       },
-      store: new SqliteSessionStore(uw.db),
+      store: new SqliteSessionStore(uw.db, uw.logger.child({ ns: 'uwave:sessions' })),
     }))
     .use(uw.passport.initialize())
     .use(addFullUrl())

--- a/src/migrations/007-sessions.cjs
+++ b/src/migrations/007-sessions.cjs
@@ -12,6 +12,7 @@ async function up({ context: uw }) {
     .addColumn('id', 'text', (col) => col.primaryKey())
     .addColumn('data', 'jsonb', (col) => col.notNull())
     .addColumn('created_at', 'timestamp', (col) => col.notNull().defaultTo(sql`(strftime('%FT%TZ', 'now'))`))
+    .addColumn('expires_at', 'timestamp', (col) => col.notNull().defaultTo(sql`(strftime('%FT%TZ', 'now', '+1 hour'))`))
     .execute();
 }
 

--- a/src/migrations/007-sessions.cjs
+++ b/src/migrations/007-sessions.cjs
@@ -1,0 +1,27 @@
+'use strict';
+
+const { sql } = require('kysely');
+
+/**
+ * @param {import('umzug').MigrationParams<import('../Uwave').default>} params
+ */
+async function up({ context: uw }) {
+  const { db } = uw;
+
+  await db.schema.createTable('sessions')
+    .addColumn('id', 'text', (col) => col.primaryKey())
+    .addColumn('data', 'jsonb', (col) => col.notNull())
+    .addColumn('created_at', 'timestamp', (col) => col.notNull().defaultTo(sql`(strftime('%FT%TZ', 'now'))`))
+    .execute();
+}
+
+/**
+ * @param {import('umzug').MigrationParams<import('../Uwave').default>} params
+ */
+async function down({ context: uw }) {
+  const { db } = uw;
+
+  await db.schema.dropTable('sessions').execute();
+}
+
+module.exports = { up, down };

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -163,6 +163,12 @@ export interface MigrationTable {
   name: string,
 }
 
+export interface SessionTable {
+  id: string, // express-session ID
+  data: JSONB<JsonObject>,
+  createdAt: Generated<Date>,
+}
+
 export interface SocketMessageTable {
   id: string,
   targetUserID: UserID | null,
@@ -186,6 +192,7 @@ export interface Database {
   playlistItems: PlaylistItemTable,
   historyEntries: HistoryEntryTable,
   feedback: FeedbackTable,
+  sessions: SessionTable,
   socketMessageQueue: SocketMessageTable,
 }
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -167,6 +167,7 @@ export interface SessionTable {
   id: string, // express-session ID
   data: JSONB<JsonObject>,
   createdAt: Generated<Date>,
+  expiresAt: Date,
 }
 
 export interface SocketMessageTable {

--- a/src/utils/SqliteSessionStore.js
+++ b/src/utils/SqliteSessionStore.js
@@ -1,17 +1,26 @@
 import { Store } from 'express-session';
 import { callbackify } from 'node:util';
-import { fromJson, json, jsonb } from './sqlite.js';
-import { addHours, addMilliseconds } from 'date-fns';
+import {
+  fromJson,
+  json,
+  jsonb,
+  now,
+} from './sqlite.js';
+import { addHours, addMilliseconds, isBefore } from 'date-fns';
 
 export default class SqliteSessionStore extends Store {
   #db;
 
+  #logger;
+
   /**
    * @param {import('kysely').Kysely<import('../schema.js').Database>} db
+   * @param {import('pino').Logger} logger
    */
-  constructor(db) {
+  constructor(db, logger) {
     super();
     this.#db = db;
+    this.#logger = logger;
   }
 
   /**
@@ -25,6 +34,16 @@ export default class SqliteSessionStore extends Store {
     return addHours(new Date(), 1);
   }
 
+  async #cleanup() {
+    const result = await this.#db.deleteFrom('sessions')
+      .where('expiresAt', '<', now)
+      .executeTakeFirst();
+
+    if (result != null) {
+      this.#logger.debug({ sessionsDeleted: result.numDeletedRows }, 'cleaned up stale express-sessions');
+    }
+  }
+
   /**
    * @param {string} sid
    * @param {(
@@ -36,10 +55,18 @@ export default class SqliteSessionStore extends Store {
     callbackify(async () => {
       const row = await this.#db.selectFrom('sessions')
         .where('id', '=', sid)
-        .select((eb) => json(eb.ref('data')).as('data'))
+        .select(['expiresAt', (eb) => json(eb.ref('data')).as('data')])
         .executeTakeFirst();
 
       if (row != null) {
+        if (isBefore(row.expiresAt, new Date())) {
+          this.#cleanup().catch((err) => {
+            this.#logger.warn({ err }, 'automatic express-session cleanup failed');
+          });
+
+          return null;
+        }
+
         return /** @type {import('express-session').SessionData | null} */ (
           /** @type {unknown} */ (fromJson(row.data))
         );
@@ -107,6 +134,15 @@ export default class SqliteSessionStore extends Store {
         .select((eb) => eb.fn.countAll().as('count'))
         .executeTakeFirstOrThrow();
       return Number(count);
+    })(callback);
+  }
+
+  /**
+   * @param {(err?: unknown) => void} callback
+   */
+  clear(callback) {
+    callbackify(async () => {
+      await this.#db.deleteFrom('sessions').execute();
     })(callback);
   }
 }

--- a/src/utils/SqliteSessionStore.js
+++ b/src/utils/SqliteSessionStore.js
@@ -1,0 +1,67 @@
+import { Store } from 'express-session';
+import { Kysely } from 'kysely';
+import { callbackify } from 'node:util';
+import { fromJson, json, jsonb } from './sqlite.js';
+
+export default class SqliteSessionStore extends Store {
+  #db
+
+  /**
+   * @param {Kysely<import('../schema.js').Database>} db
+   */
+  constructor(db) {
+    super();
+    this.#db = db;
+  }
+
+  /**
+   * @param {string} sid
+   * @param {(err: unknown, session?: import('express-session').SessionData | null) => void} callback
+   */
+  get(sid, callback) {
+    callbackify(async () => {
+      const row = await this.#db.selectFrom('sessions')
+        .where('id', '=', sid)
+        .select((eb) => json(eb.ref('data')).as('data'))
+        .executeTakeFirst();
+
+      if (row != null) {
+        return /** @type {import('express-session').SessionData | null} */ (
+          /** @type {unknown} */ (fromJson(row.data))
+        );
+      }
+
+      return null;
+    })(callback);
+  }
+
+  /**
+   * @param {string} sid
+   * @param {import('express-session').SessionData} session
+   * @param {(err?: unknown) => void} callback
+   */
+  set(sid, session, callback) {
+    callbackify(async () => {
+      await this.#db.replaceInto('sessions')
+        .values({
+          id: sid,
+          data: jsonb(/** @type {import('type-fest').JsonObject} */ (
+            /** @type {unknown} */ (session)
+          )),
+        })
+        .executeTakeFirstOrThrow();
+    })(callback);
+  }
+
+  /**
+   * @param {string} sid
+   * @param {(err?: unknown) => void} callback
+   */
+  destroy(sid, callback) {
+    callbackify(async () => {
+      await this.#db.deleteFrom('sessions')
+        .where('id', '=', sid)
+        .executeTakeFirstOrThrow();
+    })(callback);
+  }
+}

--- a/src/utils/SqliteSessionStore.js
+++ b/src/utils/SqliteSessionStore.js
@@ -1,13 +1,13 @@
 import { Store } from 'express-session';
-import { Kysely } from 'kysely';
 import { callbackify } from 'node:util';
 import { fromJson, json, jsonb } from './sqlite.js';
+import { addHours, addMilliseconds } from 'date-fns';
 
 export default class SqliteSessionStore extends Store {
-  #db
+  #db;
 
   /**
-   * @param {Kysely<import('../schema.js').Database>} db
+   * @param {import('kysely').Kysely<import('../schema.js').Database>} db
    */
   constructor(db) {
     super();
@@ -15,8 +15,22 @@ export default class SqliteSessionStore extends Store {
   }
 
   /**
+   * @param {import('express-session').SessionData} session
+   */
+  #sessionExpiration(session) {
+    const { maxAge } = session.cookie;
+    if (maxAge != null) {
+      return addMilliseconds(new Date(), maxAge);
+    }
+    return addHours(new Date(), 1);
+  }
+
+  /**
    * @param {string} sid
-   * @param {(err: unknown, session?: import('express-session').SessionData | null) => void} callback
+   * @param {(
+   *   err: unknown,
+   *   session?: import('express-session').SessionData | null,
+   * ) => void} callback
    */
   get(sid, callback) {
     callbackify(async () => {
@@ -41,6 +55,8 @@ export default class SqliteSessionStore extends Store {
    * @param {(err?: unknown) => void} callback
    */
   set(sid, session, callback) {
+    const expiresAt = this.#sessionExpiration(session);
+
     callbackify(async () => {
       await this.#db.replaceInto('sessions')
         .values({
@@ -48,7 +64,24 @@ export default class SqliteSessionStore extends Store {
           data: jsonb(/** @type {import('type-fest').JsonObject} */ (
             /** @type {unknown} */ (session)
           )),
+          expiresAt,
         })
+        .executeTakeFirstOrThrow();
+    })(callback);
+  }
+
+  /**
+   * @param {string} sid
+   * @param {import('express-session').SessionData} session
+   * @param {(err?: unknown) => void} callback
+   */
+  touch(sid, session, callback) {
+    const expiresAt = this.#sessionExpiration(session);
+
+    callbackify(async () => {
+      await this.#db.updateTable('sessions')
+        .where('id', '=', sid)
+        .set({ expiresAt })
         .executeTakeFirstOrThrow();
     })(callback);
   }
@@ -62,6 +95,18 @@ export default class SqliteSessionStore extends Store {
       await this.#db.deleteFrom('sessions')
         .where('id', '=', sid)
         .executeTakeFirstOrThrow();
+    })(callback);
+  }
+
+  /**
+   * @param {(err: unknown, length?: number) => void} callback
+   */
+  length(callback) {
+    callbackify(async () => {
+      const { count } = await this.#db.selectFrom('sessions')
+        .select((eb) => eb.fn.countAll().as('count'))
+        .executeTakeFirstOrThrow();
+      return Number(count);
     })(callback);
   }
 }


### PR DESCRIPTION
After this, Redis will only be used for:
- disconnected-ness state
- online users
- guest count. this should perhaps just use a state variable!
- pub/sub. this should perhaps just use an event emitter!

The latter two were done that way to theoretically support a multi-node setup, but that was never really supported by other parts of the code, even less so now that sqlite is the main database.