### PR TITLE
Add chat backscroll endpoint

### DIFF
--- a/locale/en.ftl
+++ b/locale/en.ftl
@@ -28,6 +28,7 @@ error-no-self-mute =
     [unmute] You can't unmute yourself.
     *[mute] You can't mute yourself.
   }
+error-muted = You are muted and cannot send chat messages.
 error-source-not-found = Source "{ $name }" not found.
 error-source-no-import = Source "{ $name }" does not support importing.
 error-too-many-name-changes = You can only change your username five times per hour. Try again in { $retry-after }.

--- a/src/controllers/chat.js
+++ b/src/controllers/chat.js
@@ -6,6 +6,7 @@ import toListResponse from '../utils/toListResponse.js';
 
 /**
  * @typedef {import('../schema').UserID} UserID
+ * @typedef {import('../redisMessages.js').ServerActionParameters} ServerActionParameters
  */
 
 const BACKSCROLL_LENGTH = 20;
@@ -120,18 +121,17 @@ async function getBackscroll(req) {
   const rows = await db.selectFrom('socketMessageQueue')
     .where('command', '=', 'chatMessage')
     .innerJoin('users', (join) => join
-      .on('users.id', '=', (eb) => sql`${eb.ref('data')}->>'userID'`)
-    )
+      .on('users.id', '=', (eb) => sql`${eb.ref('data')}->>'userID'`))
     .select([
       (eb) => json(eb.ref('data')).as('data'),
       ...users.publicUserColumns,
     ])
     .orderBy('socketMessageQueue.id', 'desc')
     .limit(BACKSCROLL_LENGTH)
-    .execute()
+    .execute();
 
   const messages = rows.map((row) => {
-    const message = /** @type {import('../redisMessages.js').ServerActionParameters['chat:message']} */ (fromJson(row.data));
+    const message = /** @type {ServerActionParameters['chat:message']} */ (fromJson(row.data));
     return {
       _id: message.id,
       /** Deprecated: timestamp as unixy milliseconds */

--- a/src/controllers/chat.js
+++ b/src/controllers/chat.js
@@ -130,7 +130,7 @@ async function getBackscroll(req) {
     .limit(BACKSCROLL_LENGTH)
     .execute();
 
-  const messages = rows.map((row) => {
+  const messages = rows.reverse().map((row) => {
     const message = /** @type {ServerActionParameters['chat:message']} */ (fromJson(row.data));
     return {
       _id: message.id,

--- a/src/controllers/chat.js
+++ b/src/controllers/chat.js
@@ -1,9 +1,14 @@
+import { sql } from 'kysely';
 import { UserNotFoundError, CannotSelfMuteError } from '../errors/index.js';
+import { fromJson, json } from '../utils/sqlite.js';
 import toItemResponse from '../utils/toItemResponse.js';
+import toListResponse from '../utils/toListResponse.js';
 
 /**
  * @typedef {import('../schema').UserID} UserID
  */
+
+const BACKSCROLL_LENGTH = 20;
 
 /**
  * @typedef {object} MuteUserParams
@@ -106,10 +111,58 @@ async function deleteMessage(req) {
   return toItemResponse({});
 }
 
+/**
+ * @type {import('../types.js').Controller<{}>}
+ */
+async function getBackscroll(req) {
+  const { db, users } = req.uwave;
+
+  const rows = await db.selectFrom('socketMessageQueue')
+    .where('command', '=', 'chatMessage')
+    .innerJoin('users', (join) => join
+      .on('users.id', '=', (eb) => sql`${eb.ref('data')}->>'userID'`)
+    )
+    .select([
+      (eb) => json(eb.ref('data')).as('data'),
+      ...users.publicUserColumns,
+    ])
+    .orderBy('socketMessageQueue.id', 'desc')
+    .limit(BACKSCROLL_LENGTH)
+    .execute()
+
+  const messages = rows.map((row) => {
+    const message = /** @type {import('../redisMessages.js').ServerActionParameters['chat:message']} */ (fromJson(row.data));
+    return {
+      id: message.id,
+      /** Deprecated: timestamp as unixy milliseconds */
+      timestamp: message.timestamp,
+      createdAt: new Date(message.timestamp),
+      message: message.message,
+      user: {
+        id: row.id,
+        username: row.username,
+        slug: row.slug,
+        createdAt: row.createdAt,
+        updatedAt: row.updatedAt,
+        avatar: row.avatar,
+        roles: row.roles == null ? [] : fromJson(row.roles),
+      },
+    };
+  });
+
+  return toListResponse(messages, {
+    included: {
+      user: ['user'],
+    },
+    url: req.fullUrl,
+  });
+}
+
 export {
   muteUser,
   unmuteUser,
   deleteAll,
   deleteByUser,
   deleteMessage,
+  getBackscroll,
 };

--- a/src/controllers/chat.js
+++ b/src/controllers/chat.js
@@ -133,13 +133,13 @@ async function getBackscroll(req) {
   const messages = rows.map((row) => {
     const message = /** @type {import('../redisMessages.js').ServerActionParameters['chat:message']} */ (fromJson(row.data));
     return {
-      id: message.id,
+      _id: message.id,
       /** Deprecated: timestamp as unixy milliseconds */
       timestamp: message.timestamp,
       createdAt: new Date(message.timestamp),
       message: message.message,
       user: {
-        id: row.id,
+        _id: row.id,
         username: row.username,
         slug: row.slug,
         createdAt: row.createdAt,
@@ -158,6 +158,23 @@ async function getBackscroll(req) {
   });
 }
 
+/**
+ * @typedef {object} SendMessageBody
+ * @prop {string} message
+ */
+
+/**
+ * @type {import('../types').AuthenticatedController<{}, {}, SendMessageBody>}
+ */
+async function sendMessage(req) {
+  const { user } = req;
+  const { message } = req.body;
+  const { chat } = req.uwave;
+
+  const result = await chat.send(user, message);
+  return toItemResponse(result);
+}
+
 export {
   muteUser,
   unmuteUser,
@@ -165,4 +182,5 @@ export {
   deleteByUser,
   deleteMessage,
   getBackscroll,
+  sendMessage,
 };

--- a/src/errors/index.js
+++ b/src/errors/index.js
@@ -228,6 +228,12 @@ const CannotSelfMuteError = createErrorClass('CannotSelfMuteError', {
   base: Forbidden,
 });
 
+const ChatMutedError = createErrorClass('ChatMutedError', {
+  code: 'chat-muted',
+  string: 'errors.chatMuted',
+  base: Forbidden,
+});
+
 const SourceNotFoundError = createErrorClass('SourceNotFoundError', {
   code: 'source-not-found',
   string: 'error-source-not-found',
@@ -295,6 +301,7 @@ export {
   ItemNotInPlaylistError,
   CannotSelfFavoriteError,
   CannotSelfMuteError,
+  ChatMutedError,
   SourceNotFoundError,
   SourceNoImportError,
   EmptyPlaylistError,

--- a/src/errors/index.js
+++ b/src/errors/index.js
@@ -230,7 +230,7 @@ const CannotSelfMuteError = createErrorClass('CannotSelfMuteError', {
 
 const ChatMutedError = createErrorClass('ChatMutedError', {
   code: 'chat-muted',
-  string: 'errors.chatMuted',
+  string: 'error-muted',
   base: Forbidden,
 });
 

--- a/src/plugins/chat.js
+++ b/src/plugins/chat.js
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import routes from '../routes/chat.js';
 import { now } from '../utils/sqlite.js';
+import { ChatMutedError } from '../errors/index.js';
 
 /**
  * @typedef {import('../schema.js').UserID} UserID
@@ -102,19 +103,27 @@ class Chat {
 
   /**
    * @param {User} user
-   * @param {string} message
+   * @param {string} text
    */
-  async send(user, message) {
+  async send(user, text) {
     if (await this.isMuted(user)) {
-      return;
+      throw new ChatMutedError();
     }
 
-    this.#uw.publish('chat:message', {
-      id: randomUUID(),
-      userID: user.id,
-      message: this.truncate(message),
-      timestamp: Date.now(),
-    });
+    const id = randomUUID();
+    const userID = user.id;
+    const message = this.truncate(text);
+    const timestamp = Date.now();
+
+    this.#uw.publish('chat:message', { id, userID, message, timestamp });
+
+    return {
+      _id: id,
+      timestamp,
+      createdAt: new Date(timestamp),
+      message,
+      user,
+    };
   }
 
   /**

--- a/src/plugins/chat.js
+++ b/src/plugins/chat.js
@@ -115,7 +115,9 @@ class Chat {
     const message = this.truncate(text);
     const timestamp = Date.now();
 
-    this.#uw.publish('chat:message', { id, userID, message, timestamp });
+    this.#uw.publish('chat:message', {
+      id, userID, message, timestamp,
+    });
 
     return {
       _id: id,

--- a/src/plugins/users.js
+++ b/src/plugins/users.js
@@ -64,6 +64,32 @@ class UsersRepository {
     this.#logger = uw.logger.child({ ns: 'uwave:users' });
   }
 
+  publicUserColumns = /** @type {const} */ ([
+    'users.id',
+    'users.username',
+    'users.slug',
+    'users.activePlaylistID',
+    'users.pendingActivation',
+    'users.createdAt',
+    'users.updatedAt',
+    /** @param {import('kysely').ExpressionBuilder<import('../schema.js').Database, 'users'>} eb */
+    (eb) => avatarColumn(eb).as('avatar'),
+    /** @param {import('kysely').ExpressionBuilder<import('../schema.js').Database, 'users'>} eb */
+    (eb) => userRolesColumn(eb).as('roles'),
+  ]);
+
+  /**
+   * @template {{ roles: import('../utils/sqlite.js').SerializedJSON<string[]> | null }} T
+   * @param {T} user
+   * @returns {Omit<T, 'roles'> & { roles: string[] }}
+   */
+  parsePublicUserColumns(user) {
+    return {
+      ...user,
+      roles: user.roles != null ? fromJson(user.roles) : [],
+    };
+  }
+
   /**
    * @param {string} [filter]
    * @param {{ offset?: number, limit?: number }} [pagination]
@@ -77,17 +103,7 @@ class UsersRepository {
     } = pagination;
 
     let query = db.selectFrom('users')
-      .select([
-        'users.id',
-        'users.username',
-        'users.slug',
-        'users.activePlaylistID',
-        'users.pendingActivation',
-        'users.createdAt',
-        'users.updatedAt',
-        (eb) => avatarColumn(eb).as('avatar'),
-        (eb) => userRolesColumn(eb).as('roles'),
-      ])
+      .select(this.publicUserColumns)
       .offset(offset)
       .limit(limit);
     if (filter != null) {
@@ -113,7 +129,7 @@ class UsersRepository {
       totalQuery,
     ]);
 
-    return new Page(users, {
+    return new Page(users.map(this.parsePublicUserColumns), {
       pageSize: limit,
       filtered: Number(filtered.count),
       total: Number(total.count),
@@ -143,23 +159,10 @@ class UsersRepository {
   async getUsersByIds(ids, tx = this.#uw.db) {
     const users = await tx.selectFrom('users')
       .where('id', 'in', ids)
-      .select([
-        'users.id',
-        'users.username',
-        'users.slug',
-        'users.activePlaylistID',
-        'users.pendingActivation',
-        'users.createdAt',
-        'users.updatedAt',
-        (eb) => avatarColumn(eb).as('avatar'),
-        (eb) => userRolesColumn(eb).as('roles'),
-      ])
+      .select(this.publicUserColumns)
       .execute();
 
-    return users.map((user) => ({
-      ...user,
-      roles: user.roles != null ? fromJson(user.roles) : [],
-    }));
+    return users.map(this.parsePublicUserColumns);
   }
 
   /**

--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -8,7 +8,14 @@ import { Permissions } from '../plugins/acl.js';
 
 function chatRoutes() {
   return Router()
+    // GET /chat/ - Get recent chat messages
     .get('/', route(controller.getBackscroll))
+    // POST /chat/ - Send a chat message
+    .post('/',
+      protect(Permissions.ChatSend),
+      schema(validations.sendChatMessage),
+      route(controller.sendMessage)
+    )
     // DELETE /chat/ - Clear the chat (delete all messages).
     .delete(
       '/',

--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -11,10 +11,11 @@ function chatRoutes() {
     // GET /chat/ - Get recent chat messages
     .get('/', route(controller.getBackscroll))
     // POST /chat/ - Send a chat message
-    .post('/',
+    .post(
+      '/',
       protect(Permissions.ChatSend),
       schema(validations.sendChatMessage),
-      route(controller.sendMessage)
+      route(controller.sendMessage),
     )
     // DELETE /chat/ - Clear the chat (delete all messages).
     .delete(

--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -8,6 +8,7 @@ import { Permissions } from '../plugins/acl.js';
 
 function chatRoutes() {
   return Router()
+    .get('/', route(controller.getBackscroll))
     // DELETE /chat/ - Clear the chat (delete all messages).
     .delete(
       '/',

--- a/src/validations.js
+++ b/src/validations.js
@@ -213,7 +213,7 @@ export const getRoomHistory = /** @type {const} */ ({
 // Validations for chat routes:
 
 export const sendChatMessage = /** @type {const} */ ({
-    body: {
+  body: {
     type: 'object',
     properties: {
       message: { type: 'string', minLength: 1 },

--- a/src/validations.js
+++ b/src/validations.js
@@ -212,6 +212,16 @@ export const getRoomHistory = /** @type {const} */ ({
 
 // Validations for chat routes:
 
+export const sendChatMessage = /** @type {const} */ ({
+    body: {
+    type: 'object',
+    properties: {
+      message: { type: 'string', minLength: 1 },
+    },
+    required: ['message'],
+  },
+});
+
 export const deleteChatByUser = /** @type {const} */ ({
   params: {
     type: 'object',

--- a/test/chat.mjs
+++ b/test/chat.mjs
@@ -19,49 +19,51 @@ describe('Chat', () => {
     await uw.destroy();
   });
 
-  it('can broadcast chat messages', async () => {
-    const user = await uw.test.createUser();
+  describe('WebSocket', () => {
+    it('can broadcast chat messages', async () => {
+      const user = await uw.test.createUser();
 
-    const ws = await uw.test.connectToWebSocketAs(user);
+      const ws = await uw.test.connectToWebSocketAs(user);
 
-    const receivedMessages = [];
-    ws.on('message', (data) => {
-      receivedMessages.push(JSON.parse(data));
+      const receivedMessages = [];
+      ws.on('message', (data) => {
+        receivedMessages.push(JSON.parse(data));
+      });
+
+      ws.send(JSON.stringify({ command: 'sendChat', data: 'Message text' }));
+
+      await retryFor(1500, () => {
+        assert(receivedMessages.some((message) => message.command === 'chatMessage' && message.data.userID === user.id && message.data.message === 'Message text'));
+      });
     });
 
-    ws.send(JSON.stringify({ command: 'sendChat', data: 'Message text' }));
+    it('does not broadcast chat messages from muted users', async () => {
+      const user = await uw.test.createUser();
+      const token = await uw.test.createTestSessionToken(user);
+      await uw.acl.allow(user, ['admin']);
+      const mutedUser = await uw.test.createUser();
 
-    await retryFor(1500, () => {
-      assert(receivedMessages.some((message) => message.command === 'chatMessage' && message.data.userID === user.id && message.data.message === 'Message text'));
-    });
-  });
+      await supertest(uw.server)
+        .post(`/api/users/${mutedUser.id}/mute`)
+        .set('Cookie', `uwsession=${token}`)
+        .send({ time: 60 /* seconds */ })
+        .expect(200);
 
-  it('does not broadcast chat messages from muted users', async () => {
-    const user = await uw.test.createUser();
-    const token = await uw.test.createTestSessionToken(user);
-    await uw.acl.allow(user, ['admin']);
-    const mutedUser = await uw.test.createUser();
+      const ws = await uw.test.connectToWebSocketAs(user);
+      const mutedWs = await uw.test.connectToWebSocketAs(mutedUser);
 
-    await supertest(uw.server)
-      .post(`/api/users/${mutedUser.id}/mute`)
-      .set('Cookie', `uwsession=${token}`)
-      .send({ time: 60 /* seconds */ })
-      .expect(200);
+      const receivedMessages = [];
+      ws.on('message', (data) => {
+        receivedMessages.push(JSON.parse(data));
+      });
 
-    const ws = await uw.test.connectToWebSocketAs(user);
-    const mutedWs = await uw.test.connectToWebSocketAs(mutedUser);
+      ws.send(JSON.stringify({ command: 'sendChat', data: 'unmuted' }));
+      mutedWs.send(JSON.stringify({ command: 'sendChat', data: 'muted' }));
 
-    const receivedMessages = [];
-    ws.on('message', (data) => {
-      receivedMessages.push(JSON.parse(data));
-    });
-
-    ws.send(JSON.stringify({ command: 'sendChat', data: 'unmuted' }));
-    mutedWs.send(JSON.stringify({ command: 'sendChat', data: 'muted' }));
-
-    await retryFor(1500, () => {
-      assert(receivedMessages.some((message) => message.command === 'chatMessage' && message.data.userID === user.id));
-      assert(!receivedMessages.some((message) => message.command === 'chatMessage' && message.data.userID === mutedUser.id));
+      await retryFor(1500, () => {
+        assert(receivedMessages.some((message) => message.command === 'chatMessage' && message.data.userID === user.id));
+        assert(!receivedMessages.some((message) => message.command === 'chatMessage' && message.data.userID === mutedUser.id));
+      });
     });
   });
 

--- a/test/chat.mjs
+++ b/test/chat.mjs
@@ -64,6 +64,100 @@ describe('Chat', () => {
     });
   });
 
+  describe('POST /chat', () => {
+    it('requires authentication', async () => {
+      await supertest(uw.server)
+        .post('/api/chat')
+        .send({ message: 'blah' })
+        .expect(401);
+    });
+
+    it('requires the chat.send permission', async () => {
+      const user = await uw.test.createUser();
+      const token = await uw.test.createTestSessionToken(user);
+
+      await supertest(uw.server)
+        .post('/api/chat')
+        .set('Cookie', `uwsession=${token}`)
+        .send({ message: 'blah' })
+        .expect(403);
+
+      await uw.acl.createRole('chatSender', ['chat.send']);
+      await uw.acl.allow(user, ['chatSender']);
+
+      await supertest(uw.server)
+        .post('/api/chat')
+        .set('Cookie', `uwsession=${token}`)
+        .send({ message: 'blah' })
+        .expect(200);
+    });
+
+    it('validates input', async () => {
+      const user = await uw.test.createUser();
+      const token = await uw.test.createTestSessionToken(user);
+
+      await uw.acl.createRole('chatSender', ['chat.send']);
+      await uw.acl.allow(user, ['chatSender']);
+
+      await supertest(uw.server)
+        .post('/api/chat')
+        .set('Cookie', `uwsession=${token}`)
+        .send({ not: 'a message' })
+        .expect(400);
+
+      await supertest(uw.server)
+        .post('/api/chat')
+        .set('Cookie', `uwsession=${token}`)
+        .send('text')
+        .expect(400);
+
+      await supertest(uw.server)
+        .post('/api/chat')
+        .set('Cookie', `uwsession=${token}`)
+        .send({ message: null })
+        .expect(400);
+
+      await supertest(uw.server)
+        .post('/api/chat')
+        .set('Cookie', `uwsession=${token}`)
+        .send({ message: '' })
+        .expect(400);
+    });
+
+    it('broadcasts a chat message', async () => {
+      const user = await uw.test.createUser();
+      const token = await uw.test.createTestSessionToken(user);
+      const ws = await uw.test.connectToWebSocketAs(user);
+
+      await uw.acl.createRole('chatSender', ['chat.send']);
+      await uw.acl.allow(user, ['chatSender']);
+
+      const res = await supertest(uw.server)
+        .post('/api/chat')
+        .set('Cookie', `uwsession=${token}`)
+        .send({ message: 'HTTP message text' })
+        .expect(200);
+      sinon.assert.match(res.body.data, {
+        _id: sinon.match.string,
+        message: sinon.match.string,
+      });
+
+      const receivedMessages = [];
+      ws.on('message', (data) => {
+        receivedMessages.push(JSON.parse(data));
+      });
+
+      ws.send(JSON.stringify({ command: 'sendChat', data: 'HTTP message text' }));
+      await retryFor(5_000, () => (
+        receivedMessages.some((message) => (
+          message.command === 'chatMessage'
+          && message.data.userID === user.id
+          && message.data.message === 'HTTP message text'
+        ))
+      ));
+    });
+  });
+
   describe('DELETE /chat/', () => {
     it('requires authentication', async () => {
       await supertest(uw.server)

--- a/test/chat.mjs
+++ b/test/chat.mjs
@@ -164,6 +164,51 @@ describe('Chat', () => {
         ))
       ));
     });
+
+    it('does not broadcast chat messages from muted users', async () => {
+      const adminUser = await uw.test.createUser();
+      const adminToken = await uw.test.createTestSessionToken(adminUser);
+      await uw.acl.allow(adminUser, ['admin']);
+      const mutedUser = await uw.test.createUser();
+      const mutedToken = await uw.test.createTestSessionToken(mutedUser);
+
+      await uw.acl.createRole('chatSender', ['chat.send']);
+      await uw.acl.allow(mutedUser, ['chatSender']);
+
+      await supertest(uw.server)
+        .post(`/api/users/${mutedUser.id}/mute`)
+        .set('Cookie', `uwsession=${adminToken}`)
+        .send({ time: 60 /* seconds */ })
+        .expect(200);
+
+      const adminWs = await uw.test.connectToWebSocketAs(adminUser);
+      // We do need to be connected to be allowed to send a message
+      const mutedWs = await uw.test.connectToWebSocketAs(mutedUser);
+
+      const receivedMessages = [];
+      adminWs.on('message', (data) => {
+        receivedMessages.push(JSON.parse(data));
+      });
+
+      const res = await supertest(uw.server)
+        .post('/api/chat')
+        .set('Cookie', `uwsession=${mutedToken}`)
+        .send({ message: 'Should not arrive' })
+        .expect(403);
+      sinon.assert.match(res.body.errors[0], { code: 'chat-muted' });
+
+      // Send an unmuted message as well to ~try~ to verify that the muted message _did not_ go through.
+      await supertest(uw.server)
+        .post('/api/chat')
+        .set('Cookie', `uwsession=${adminToken}`)
+        .send({ message: 'Should arrive' })
+        .expect(200);
+
+      await retryFor(1500, () => {
+        assert(receivedMessages.some((message) => message.command === 'chatMessage' && message.data.userID === adminUser.id));
+        assert(!receivedMessages.some((message) => message.command === 'chatMessage' && message.data.userID === mutedUser.id));
+      });
+    });
   });
 
   describe('DELETE /chat/', () => {

--- a/test/chat.mjs
+++ b/test/chat.mjs
@@ -2,6 +2,7 @@ import { randomUUID } from 'crypto';
 import assert from 'assert';
 import * as sinon from 'sinon';
 import supertest from 'supertest';
+import delay from 'delay';
 import createUwave from './utils/createUwave.mjs';
 import { retryFor } from './utils/retry.mjs';
 
@@ -65,10 +66,49 @@ describe('Chat', () => {
   });
 
   describe('GET /chat', () => {
-    it('responds', async () => {
+    it('does not require authentication', async () => {
       await supertest(uw.server)
         .get('/api/chat')
         .expect(200);
+    });
+
+    it('returns recent chat messages', async () => {
+      const user = await uw.test.createUser();
+      await uw.acl.allow(user, ['admin']);
+
+      const ws = await uw.test.connectToWebSocketAs(user);
+
+      const receivedMessages = [];
+      ws.on('message', (data) => {
+        receivedMessages.push(JSON.parse(data));
+      });
+
+      // TODO: is it important to serialize this stuff on the server side
+      // so it always gets recorded in the same order?
+      ws.send(JSON.stringify({ command: 'sendChat', data: 'a' }));
+      await delay(50);
+      ws.send(JSON.stringify({ command: 'sendChat', data: 'b' }));
+      await delay(50);
+      ws.send(JSON.stringify({ command: 'sendChat', data: 'c' }));
+
+      await retryFor(1500, () => {
+        assert.strictEqual(
+          receivedMessages.filter((message) => message.command === 'chatMessage' && message.data.userID === user.id).length,
+          3,
+        );
+      });
+
+      const res = await supertest(uw.server)
+        .get('/api/chat')
+        .expect(200);
+      sinon.assert.match(res.body.data, [
+        sinon.match({ user: user.id, message: 'a', createdAt: sinon.match.string }),
+        sinon.match({ user: user.id, message: 'b', createdAt: sinon.match.string }),
+        sinon.match({ user: user.id, message: 'c', createdAt: sinon.match.string }),
+      ]);
+      sinon.assert.match(res.body.included, {
+        user: [sinon.match({ _id: user.id })],
+      });
     });
   });
 

--- a/test/chat.mjs
+++ b/test/chat.mjs
@@ -197,7 +197,8 @@ describe('Chat', () => {
         .expect(403);
       sinon.assert.match(res.body.errors[0], { code: 'chat-muted' });
 
-      // Send an unmuted message as well to ~try~ to verify that the muted message _did not_ go through.
+      // Send an unmuted message as well to ~try~ to verify that the
+      // muted message _did not_ go through.
       await supertest(uw.server)
         .post('/api/chat')
         .set('Cookie', `uwsession=${adminToken}`)
@@ -208,6 +209,8 @@ describe('Chat', () => {
         assert(receivedMessages.some((message) => message.command === 'chatMessage' && message.data.userID === adminUser.id));
         assert(!receivedMessages.some((message) => message.command === 'chatMessage' && message.data.userID === mutedUser.id));
       });
+
+      mutedWs.close();
     });
   });
 

--- a/test/chat.mjs
+++ b/test/chat.mjs
@@ -64,6 +64,14 @@ describe('Chat', () => {
     });
   });
 
+  describe('GET /chat', () => {
+    it('responds', async () => {
+      await supertest(uw.server)
+        .get('/api/chat')
+        .expect(200);
+    });
+  });
+
   describe('POST /chat', () => {
     it('requires authentication', async () => {
       await supertest(uw.server)


### PR DESCRIPTION
Exxxperimental.

Could be used to show some chat history when you first join.

Later, the message queue cleanup could be made a bit more intelligent, so it could leave chat messages in for longer for example.