### PR TITLE
Move away from Redis for key-value usages

### DIFF
--- a/src/AuthRegistry.js
+++ b/src/AuthRegistry.js
@@ -1,17 +1,17 @@
-import assert from 'node:assert';
+import { sql } from 'kysely';
 import nodeCrypto from 'node:crypto';
 import { promisify } from 'node:util';
 
 const randomBytes = promisify(nodeCrypto.randomBytes);
 
 class AuthRegistry {
-  #redis;
+  #db;
 
   /**
-   * @param {import('ioredis').default} redis
+   * @param {import('./schema.js').Kysely} db
    */
-  constructor(redis) {
-    this.#redis = redis;
+  constructor(db) {
+    this.#db = db;
   }
 
   /**
@@ -20,7 +20,15 @@ class AuthRegistry {
    */
   async createAuthToken(user, sessionID) {
     const token = (await randomBytes(64)).toString('hex');
-    await this.#redis.set(`http-api:socketAuth:${token}`, `${user.id}/${sessionID}`, 'EX', 60);
+
+    await this.#db.insertInto('socketAuthTokens')
+      .values({
+        id: token,
+        userID: user.id,
+        sessionID,
+      })
+      .execute();
+
     return token;
   }
 
@@ -31,30 +39,19 @@ class AuthRegistry {
     if (token.length !== 128) {
       throw new Error('Invalid token');
     }
-    const result = await this.#redis
-      .multi()
-      .get(`http-api:socketAuth:${token}`)
-      .del(`http-api:socketAuth:${token}`)
-      .exec();
-    assert(result);
 
-    const [err, authParts] = result[0];
-    if (err) {
-      throw err;
-    }
-    if (typeof authParts !== 'string') {
-      throw new Error('Invalid auth parts');
-    }
+    const result = await this.#db.deleteFrom('socketAuthTokens')
+      .where('id', '=', token)
+      .where(
+        'createdAt',
+        '>',
+        /** @type {import('kysely').RawBuilder<Date>} */
+        (sql`(strftime('%FT%TZ', 'now', '-60 seconds'))`),
+      )
+      .returning(['userID', 'sessionID'])
+      .executeTakeFirstOrThrow();
 
-    const index = authParts.indexOf('/');
-    if (index === -1) {
-      throw new Error('Invalid auth parts');
-    }
-
-    const userID = /** @type {import('./schema.js').UserID} */ (authParts.slice(0, index));
-    const sessionID = authParts.slice(index + 1);
-
-    return { userID, sessionID };
+    return result;
   }
 }
 

--- a/src/AuthRegistry.js
+++ b/src/AuthRegistry.js
@@ -1,17 +1,40 @@
 import { sql } from 'kysely';
 import nodeCrypto from 'node:crypto';
 import { promisify } from 'node:util';
+import { addMinutes, isAfter } from './utils/date.js';
 
 const randomBytes = promisify(nodeCrypto.randomBytes);
 
+/** @type {import('kysely').RawBuilder<Date>} */
+const earliestValidTokenTime = sql`(strftime('%FT%TZ', 'now', '-60 seconds'))`;
+
 class AuthRegistry {
   #db;
+
+  #latestCleanup = new Date();
 
   /**
    * @param {import('./schema.js').Kysely} db
    */
   constructor(db) {
     this.#db = db;
+  }
+
+  async #cleanup() {
+    await this.#db.deleteFrom('socketAuthTokens')
+      .where('createdAt', '<', earliestValidTokenTime)
+      .execute();
+  }
+
+  #autoCleanup() {
+    const now = new Date();
+    const nextCleanup = addMinutes(this.#latestCleanup, 1);
+    if (isAfter(now, nextCleanup)) {
+      this.#latestCleanup = now;
+      this.#cleanup().catch((err) => {
+        console.warn(err);
+      });
+    }
   }
 
   /**
@@ -42,14 +65,11 @@ class AuthRegistry {
 
     const result = await this.#db.deleteFrom('socketAuthTokens')
       .where('id', '=', token)
-      .where(
-        'createdAt',
-        '>',
-        /** @type {import('kysely').RawBuilder<Date>} */
-        (sql`(strftime('%FT%TZ', 'now', '-60 seconds'))`),
-      )
+      .where('createdAt', '>=', earliestValidTokenTime)
       .returning(['userID', 'sessionID'])
       .executeTakeFirstOrThrow();
+
+    this.#autoCleanup();
 
     return result;
   }

--- a/src/HttpApi.js
+++ b/src/HttpApi.js
@@ -107,7 +107,7 @@ async function httpApi(uw, options) {
 
   logger.debug(runtimeOptions, 'start HttpApi');
   uw.httpApi = Object.assign(express.Router(), {
-    authRegistry: new AuthRegistry(uw.redis),
+    authRegistry: new AuthRegistry(uw.db),
   });
 
   uw.express = express();

--- a/src/SocketServer.js
+++ b/src/SocketServer.js
@@ -167,7 +167,7 @@ class SocketServer {
     };
 
     // TODO put this behind a symbol, it's just public for tests
-    this.authRegistry = new AuthRegistry(uw.redis);
+    this.authRegistry = new AuthRegistry(uw.db);
 
     this.#wss = new WebSocketServer({
       server: options.server,

--- a/src/SocketServer.js
+++ b/src/SocketServer.js
@@ -16,7 +16,7 @@ import { subMinutes } from './utils/date.js';
 
 const { isEmpty } = lodash;
 
-export const REDIS_ACTIVE_SESSIONS = 'users';
+export const KEY_ACTIVE_SESSIONS = 'users';
 
 const PING_INTERVAL = 10_000;
 const GUEST_COUNT_INTERVAL = 2_000;
@@ -82,7 +82,7 @@ class SocketServer {
         // We do need to clear the `users` list because the lost connection handlers
         // will not do so.
         uw.socketServer.#logger.warn({ err }, 'could not initialise lost connections');
-        await uw.redis.del(REDIS_ACTIVE_SESSIONS);
+        await uw.keyv.delete(KEY_ACTIVE_SESSIONS);
       }
     });
 
@@ -391,11 +391,15 @@ class SocketServer {
         }
       },
       'user:join': async ({ userID }) => {
-        const { users, redis } = this.#uw;
+        const { users, keyv } = this.#uw;
         const user = await users.getUser(userID);
         if (user) {
           // TODO this should not be the socket server code's responsibility
-          await redis.rpush(REDIS_ACTIVE_SESSIONS, user.id);
+          const userIDs = /** @type {import('./schema').UserID[] | null} */ (
+            await keyv.get(KEY_ACTIVE_SESSIONS)
+          ) ?? [];
+          userIDs.push(user.id);
+          await keyv.set(KEY_ACTIVE_SESSIONS, userIDs);
           this.broadcast('join', serializeUser(user));
         }
       },
@@ -453,10 +457,10 @@ class SocketServer {
    * @private
    */
   async initLostConnections() {
-    const { db, redis } = this.#uw;
-    const userIDs = /** @type {import('./schema').UserID[]} */ (
-      await redis.lrange(REDIS_ACTIVE_SESSIONS, 0, -1)
-    );
+    const { db, keyv } = this.#uw;
+    const userIDs = /** @type {import('./schema').UserID[] | null} */ (
+      await keyv.get(KEY_ACTIVE_SESSIONS)
+    ) ?? [];
     const disconnectedIDs = userIDs.filter((userID) => !this.connection(userID));
 
     if (disconnectedIDs.length === 0) {

--- a/src/SocketServer.js
+++ b/src/SocketServer.js
@@ -194,9 +194,7 @@ class SocketServer {
         return;
       }
 
-      this.#recountGuests().catch((error) => {
-        this.#logger.error({ err: error }, 'counting guests failed');
-      });
+      this.#recountGuests();
     }, GUEST_COUNT_INTERVAL);
 
     this.#clientActions = {
@@ -798,24 +796,22 @@ class SocketServer {
     });
   }
 
-  async getGuestCount() {
-    const { redis } = this.#uw;
-    const rawCount = await redis.get('http-api:guests');
-    if (typeof rawCount !== 'string' || !/^\d+$/.test(rawCount)) {
-      return 0;
-    }
-    return parseInt(rawCount, 10);
+  #lastGuestCount = 0;
+
+  /** The number of unauthenticated connections. */
+  get guestCount() {
+    return this.#connections.reduce((acc, connection) => {
+      if (connection instanceof GuestConnection) {
+        return acc + 1;
+      }
+      return acc;
+    }, 0);
   }
 
-  async #recountGuests() {
-    const { redis } = this.#uw;
-    const guests = this.#connections
-      .filter((connection) => connection instanceof GuestConnection)
-      .length;
-
-    const lastGuestCount = await this.getGuestCount();
-    if (guests !== lastGuestCount) {
-      await redis.set('http-api:guests', guests);
+  #recountGuests() {
+    const guests = this.guestCount;
+    if (guests !== this.#lastGuestCount) {
+      this.#lastGuestCount = guests;
       this.broadcast('guests', guests);
     }
   }

--- a/src/controllers/now.js
+++ b/src/controllers/now.js
@@ -24,15 +24,6 @@ async function getFirstItem(uw, playlist) {
 }
 
 /**
- * @param {unknown} str
- */
-function toInt(str) {
-  if (typeof str !== 'string') return 0;
-  if (!/^\d+$/.test(str)) return 0;
-  return parseInt(str, 10);
-}
-
-/**
  * @param {import('../Uwave.js').default} uw
  */
 async function getOnlineUsers(uw) {
@@ -46,14 +37,6 @@ async function getOnlineUsers(uw) {
 }
 
 /**
- * @param {import('../Uwave.js').default} uw
- */
-async function getGuestsCount(uw) {
-  const guests = await uw.redis.get('http-api:guests');
-  return toInt(guests);
-}
-
-/**
  * @type {import('../types.js').Controller}
  */
 async function getState(req) {
@@ -62,9 +45,11 @@ async function getState(req) {
   const { passport } = uw;
   const { user, sessionID } = req;
 
+  // XXX: with sqlite there isn't really a point in making this all "parallel",
+  // but maybe it makes sense to keep so it'd reduce network waiting times with
+  // other databases in the future?
   const motd = uw.motd.get();
   const users = getOnlineUsers(uw);
-  const guests = getGuestsCount(uw);
   const roles = uw.acl.getAllRoles();
   const booth = getBoothData(uw);
   const waitlist = uw.waitlist.getUserIDs();
@@ -97,7 +82,7 @@ async function getState(req) {
     motd,
     user: user ? serializeCurrentUser(user) : null,
     users,
-    guests,
+    guests: uw.socketServer.guestCount,
     roles,
     booth,
     waitlist,

--- a/src/controllers/now.js
+++ b/src/controllers/now.js
@@ -1,7 +1,7 @@
 import { getBoothData } from './booth.js';
 import { serializeCurrentUser, serializePlaylist, serializeUser } from '../utils/serialize.js';
 import { legacyPlaylistItem } from './playlists.js';
-import { REDIS_ACTIVE_SESSIONS } from '../SocketServer.js';
+import { KEY_ACTIVE_SESSIONS } from '../SocketServer.js';
 
 /**
  * @typedef {import('../schema.js').UserID} UserID
@@ -27,7 +27,7 @@ async function getFirstItem(uw, playlist) {
  * @param {import('../Uwave.js').default} uw
  */
 async function getOnlineUsers(uw) {
-  const userIDs = /** @type {UserID[]} */ (await uw.redis.lrange(REDIS_ACTIVE_SESSIONS, 0, -1));
+  const userIDs = /** @type {UserID[] | null} */ (await uw.keyv.get(KEY_ACTIVE_SESSIONS)) ?? [];
   if (userIDs.length === 0) {
     return [];
   }

--- a/src/controllers/users.js
+++ b/src/controllers/users.js
@@ -9,7 +9,7 @@ import toItemResponse from '../utils/toItemResponse.js';
 import toListResponse from '../utils/toListResponse.js';
 import toPaginatedResponse from '../utils/toPaginatedResponse.js';
 import { muteUser, unmuteUser } from './chat.js';
-import { REDIS_ACTIVE_SESSIONS } from '../SocketServer.js';
+import { KEY_ACTIVE_SESSIONS } from '../SocketServer.js';
 
 /**
  * @typedef {import('../schema').UserID} UserID
@@ -207,7 +207,14 @@ async function disconnectUser(uw, userID) {
     }
   }
 
-  await uw.redis.lrem(REDIS_ACTIVE_SESSIONS, 0, userID);
+  const userIDs = new Set(
+    /** @type {import('../schema.js').UserID[] | null} */ (
+      await uw.keyv.get(KEY_ACTIVE_SESSIONS)
+    ) ?? [],
+  );
+  userIDs.delete(userID);
+
+  await uw.keyv.set(KEY_ACTIVE_SESSIONS, Array.from(userIDs));
 
   uw.publish('user:leave', { userID });
 }

--- a/src/middleware/requireActiveConnection.js
+++ b/src/middleware/requireActiveConnection.js
@@ -1,6 +1,6 @@
 import httpErrors from 'http-errors';
 import wrapMiddleware from '../utils/wrapMiddleware.js';
-import { REDIS_ACTIVE_SESSIONS } from '../SocketServer.js';
+import { KEY_ACTIVE_SESSIONS } from '../SocketServer.js';
 
 const { BadRequest } = httpErrors;
 
@@ -10,8 +10,12 @@ function requireActiveConnection() {
    * @param {import('../schema.js').User} user
    */
   async function isConnected(uwave, user) {
-    const onlineIDs = await uwave.redis.lrange(REDIS_ACTIVE_SESSIONS, 0, -1);
-    return onlineIDs.indexOf(user.id) !== -1;
+    const onlineIDs = new Set(
+      /** @type {import('../schema.js').UserID[] | null} */ (
+        await uwave.keyv.get(KEY_ACTIVE_SESSIONS)
+      ) ?? [],
+    );
+    return onlineIDs.has(user.id);
   }
 
   return wrapMiddleware(async (req) => {

--- a/src/migrations/008-authRegistry.cjs
+++ b/src/migrations/008-authRegistry.cjs
@@ -1,0 +1,28 @@
+'use strict';
+
+const { sql } = require('kysely');
+
+/**
+ * @param {import('umzug').MigrationParams<import('../Uwave').default>} params
+ */
+async function up({ context: uw }) {
+  const { db } = uw;
+
+  await db.schema.createTable('socket_auth_tokens')
+    .addColumn('id', 'text', (col) => col.primaryKey())
+    .addColumn('user_id', 'uuid', (col) => col.notNull().references('users.id'))
+    .addColumn('session_id', 'text', (col) => col.notNull()) // TODO: Can I add `.references('sessions.id')`?
+    .addColumn('created_at', 'timestamp', (col) => col.notNull().defaultTo(sql`(strftime('%FT%TZ', 'now'))`))
+    .execute();
+}
+
+/**
+ * @param {import('umzug').MigrationParams<import('../Uwave').default>} params
+ */
+async function down({ context: uw }) {
+  const { db } = uw;
+
+  await db.schema.dropTable('socket_auth_tokens').execute();
+}
+
+module.exports = { up, down };

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -170,6 +170,13 @@ export interface SessionTable {
   expiresAt: Date,
 }
 
+export interface SocketAuthTokenTable {
+  id: string,
+  userID: UserID,
+  sessionID: string,
+  createdAt: Generated<Date>,
+}
+
 export interface SocketMessageTable {
   id: string,
   targetUserID: UserID | null,
@@ -194,6 +201,7 @@ export interface Database {
   historyEntries: HistoryEntryTable,
   feedback: FeedbackTable,
   sessions: SessionTable,
+  socketAuthTokens: SocketAuthTokenTable,
   socketMessageQueue: SocketMessageTable,
 }
 

--- a/src/sockets/LostConnection.js
+++ b/src/sockets/LostConnection.js
@@ -45,9 +45,7 @@ class LostConnection extends Emittery {
     // we can ensure that everyone still gets the full `timeout` duration to
     // reconnect after a server restart, while also not filling up Redis with
     // session IDs that left and will never return.
-    this.#uw.redis.multi()
-      .set(this.#key, lastEventID, 'EX', seconds * 10)
-      .exec();
+    this.#uw.redis.set(this.#key, lastEventID, 'EX', seconds * 10);
   }
 
   /**

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -17,10 +17,26 @@ export function isBefore(date, dateToCompare) {
 
 /**
  * @param {Date} date
+ * @param {Date} dateToCompare
+ */
+export function isAfter(date, dateToCompare) {
+  return +date > +dateToCompare;
+}
+
+/**
+ * @param {Date} date
  * @param {number} millis
  */
 export function addMilliseconds(date, millis) {
   return new Date(+date + millis);
+}
+
+/**
+ * @param {Date} date
+ * @param {number} minutes
+ */
+export function addMinutes(date, minutes) {
+  return new Date(+date + minutes * MS_PER_MINUTE);
 }
 
 /**


### PR DESCRIPTION
The only remaining thing is the `:disconnected:` keys. And then the final bit of Redis will be the pub/sub stuff which maybe should just be an in-process event emitter.

The `:disconnected:` keys use TTLs w/ Redis which is not supported with the sqlite key-value implementation right now.