### PR TITLE
Switch tests to use vitest

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -612,7 +612,7 @@ export default ts.config(
     },
   },
   {
-    files: ['eslint.config.js'],
+    files: ['eslint.config.js', 'vitest.config.js'],
     rules: {
       'n/no-unpublished-import': 'off',
       'n/no-unpublished-require': 'off',
@@ -621,7 +621,7 @@ export default ts.config(
   {
     files: ['test/**/*.js'],
     languageOptions: {
-      globals: globals.mocha,
+      globals: globals.vitest,
     },
     rules: {
       'n/no-unpublished-require': 'off',
@@ -630,7 +630,7 @@ export default ts.config(
   {
     files: ['test/**/*.mjs'],
     languageOptions: {
-      globals: globals.mocha,
+      globals: globals.vitest,
     },
     rules: {
       'n/no-unpublished-import': 'off',

--- a/package.json
+++ b/package.json
@@ -109,14 +109,13 @@
     "@types/supertest": "^7.2.0",
     "@types/ultron": "^1.1.0",
     "@types/ws": "^8.2.0",
-    "c8": "^11.0.0",
+    "@vitest/coverage-v8": "^4.1.0",
     "concat-stream": "^2.0.0",
     "eslint": "^9.12.0",
     "eslint-plugin-import": "^2.30.0",
     "eslint-plugin-n": "^17.10.2",
     "get-port": "^7.0.0",
     "globals": "^17.0.0",
-    "mocha": "^11.0.1",
     "nock": "^14.0.0",
     "nodemon": "^3.0.1",
     "pino-pretty": "^13.0.0",
@@ -125,12 +124,13 @@
     "supertest": "^7.0.0",
     "type-fest": "^5.0.0",
     "typescript": "~5.9.2",
-    "typescript-eslint": "^8.5.0"
+    "typescript-eslint": "^8.5.0",
+    "vitest": "^4.1.0"
   },
   "scripts": {
     "lint": "eslint --cache .",
     "test": "npm run tests-only && npm run types && npm run lint",
-    "tests-only": "c8 --reporter lcov --src src mocha",
+    "tests-only": "vitest run",
     "types": "tsc -p tsconfig.json",
     "start": "nodemon --env-file-if-exists=.env dev/u-wave-dev-server.js | pino-pretty"
   }

--- a/test/acl.mjs
+++ b/test/acl.mjs
@@ -1,4 +1,7 @@
 import assert from 'assert';
+import {
+  describe, it, beforeEach, afterEach,
+} from 'vitest';
 import supertest from 'supertest';
 import * as sinon from 'sinon';
 import createUwave from './utils/createUwave.mjs';

--- a/test/authenticate.mjs
+++ b/test/authenticate.mjs
@@ -1,4 +1,7 @@
 import assert from 'assert';
+import {
+  describe, it, beforeEach, afterEach,
+} from 'vitest';
 import * as sinon from 'sinon';
 import supertest from 'supertest';
 import nock from 'nock';

--- a/test/bans.mjs
+++ b/test/bans.mjs
@@ -1,4 +1,7 @@
 import assert from 'assert';
+import {
+  describe, it, beforeEach, afterEach,
+} from 'vitest';
 import supertest from 'supertest';
 import * as sinon from 'sinon';
 import ms from 'ms';

--- a/test/booth.mjs
+++ b/test/booth.mjs
@@ -1,6 +1,9 @@
 import assert from 'node:assert';
 import { randomUUID } from 'node:crypto';
 import { setTimeout } from 'node:timers/promises';
+import {
+  describe, it, beforeEach, afterEach,
+} from 'vitest';
 import * as sinon from 'sinon';
 import supertest from 'supertest';
 import createUwave from './utils/createUwave.mjs';

--- a/test/chat.mjs
+++ b/test/chat.mjs
@@ -1,6 +1,9 @@
 import assert from 'node:assert';
 import { randomUUID } from 'node:crypto';
 import { setTimeout } from 'node:timers/promises';
+import {
+  describe, it, beforeEach, afterEach,
+} from 'vitest';
 import * as sinon from 'sinon';
 import supertest from 'supertest';
 import createUwave from './utils/createUwave.mjs';

--- a/test/config.mjs
+++ b/test/config.mjs
@@ -1,4 +1,7 @@
 import assert from 'assert';
+import {
+  describe, it, beforeEach, afterEach,
+} from 'vitest';
 import supertest from 'supertest';
 import * as sinon from 'sinon';
 import createUwave from './utils/createUwave.mjs';

--- a/test/motd.mjs
+++ b/test/motd.mjs
@@ -1,4 +1,7 @@
 import assert from 'assert';
+import {
+  describe, it, beforeEach, afterEach,
+} from 'vitest';
 import supertest from 'supertest';
 import createUwave from './utils/createUwave.mjs';
 

--- a/test/now.mjs
+++ b/test/now.mjs
@@ -1,4 +1,7 @@
 import assert from 'assert';
+import {
+  describe, it, beforeEach, afterEach,
+} from 'vitest';
 import supertest from 'supertest';
 import createUwave from './utils/createUwave.mjs';
 

--- a/test/playlists.mjs
+++ b/test/playlists.mjs
@@ -1,4 +1,7 @@
 import assert from 'assert';
+import {
+  describe, it, beforeEach, afterEach,
+} from 'vitest';
 import { inspect } from 'util';
 import supertest from 'supertest';
 import * as sinon from 'sinon';

--- a/test/server.mjs
+++ b/test/server.mjs
@@ -1,4 +1,7 @@
 import assert from 'assert';
+import {
+  describe, it, beforeEach, afterEach,
+} from 'vitest';
 import { Uwave } from 'u-wave-core';
 import createUwave from './utils/createUwave.mjs';
 

--- a/test/sockets.mjs
+++ b/test/sockets.mjs
@@ -1,7 +1,10 @@
 import { once } from 'node:events';
 import { setTimeout } from 'node:timers/promises';
-import supertest from 'supertest';
+import {
+  describe, it, beforeEach, afterEach,
+} from 'vitest';
 import * as sinon from 'sinon';
+import supertest from 'supertest';
 import createUwave from './utils/createUwave.mjs';
 import { retryFor } from './utils/retry.mjs';
 

--- a/test/sources.mjs
+++ b/test/sources.mjs
@@ -1,4 +1,7 @@
 import assert from 'assert';
+import {
+  describe, it, beforeEach, afterEach,
+} from 'vitest';
 import supertest from 'supertest';
 import * as sinon from 'sinon';
 import { Source } from '../src/Source.js';

--- a/test/users.mjs
+++ b/test/users.mjs
@@ -1,4 +1,7 @@
 import supertest from 'supertest';
+import {
+  describe, it, beforeEach, afterEach,
+} from 'vitest';
 import * as sinon from 'sinon';
 import createUwave from './utils/createUwave.mjs';
 

--- a/test/waitlist.mjs
+++ b/test/waitlist.mjs
@@ -1,5 +1,8 @@
 import assert from 'node:assert';
 import { setTimeout } from 'node:timers/promises';
+import {
+  describe, it, beforeEach, afterEach,
+} from 'vitest';
 import supertest from 'supertest';
 import * as sinon from 'sinon';
 import randomString from 'random-string';

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     include: ['./test/*.{js,cjs,mjs}'],
     coverage: {
+      enabled: true,
       provider: 'v8',
       reporter: ['lcov'],
     },

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'; // eslint-disable-line import/no-unresolved
+
+export default defineConfig({
+  test: {
+    include: ['./test/*.{js,cjs,mjs}'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['lcov'],
+    },
+  },
+});


### PR DESCRIPTION
Requires https://github.com/u-wave/core/pull/755

After that, tests can use an isolated SQLite database (in-memory or not), and run in parallel.