### PR TITLE
Emit a `user:join` on reconnection if we don't have a lost connection

### DIFF
--- a/src/SocketServer.js
+++ b/src/SocketServer.js
@@ -559,7 +559,8 @@ class SocketServer {
         if (previousConnection) {
           this.remove(previousConnection);
         } else {
-          // If there's actually no lost connection, we might've derived the reconnection flag from stale state?
+          // If there's actually no lost connection, we might've derived
+          // the reconnection flag from stale state?
           // XXX(@goto-bus-stop): validate this
           isReconnect = false;
         }

--- a/src/SocketServer.js
+++ b/src/SocketServer.js
@@ -552,11 +552,17 @@ class SocketServer {
       this.remove(connection);
     });
     connection.on('authenticate', async ({ user, sessionID, lastEventID }) => {
-      const isReconnect = await connection.isReconnect(sessionID);
+      let isReconnect = await connection.isReconnect(sessionID);
       this.#logger.info({ userId: user.id, isReconnect, lastEventID }, 'authenticated socket');
       if (isReconnect) {
         const previousConnection = this.getLostConnection(sessionID);
-        if (previousConnection) this.remove(previousConnection);
+        if (previousConnection) {
+          this.remove(previousConnection);
+        } else {
+          // If there's actually no lost connection, we might've derived the reconnection flag from stale state?
+          // XXX(@goto-bus-stop): validate this
+          isReconnect = false;
+        }
       }
 
       this.replace(connection, this.createAuthedConnection(socket, user, sessionID, lastEventID));


### PR DESCRIPTION
This prevented me from being able to log in locally, which might be a
dev setup problem, and I'm not really confident that this is a _good_
fix. But, the only downside is possibly excess `user:join` messages,
which we've always had and don't cause actual issues.
