### PR TITLE
Fill in default config values when key is missing from database

### DIFF
--- a/src/plugins/configStore.js
+++ b/src/plugins/configStore.js
@@ -131,7 +131,13 @@ class ConfigStore {
    * @public
    */
   register(key, schema) {
-    this.#validators.set(key, this.#ajv.compile(schema));
+    const validate = this.#ajv.compile(schema);
+
+    if (!validate({})) {
+      throw new Error(`configStore.register: configuration schema ${key} must support a default object`);
+    }
+
+    this.#validators.set(key, validate);
   }
 
   /**
@@ -203,13 +209,9 @@ class ConfigStore {
     const configs = Object.create(null);
     for (const [key, validate] of this.#validators.entries()) {
       const row = results.find((m) => m.name === key);
-      if (row) {
-        const value = JSON.parse(/** @type {string} */ (row.value));
-        validate(value);
-        configs[key] = value;
-      } else {
-        configs[key] = {};
-      }
+      configs[key] = row ? JSON.parse(/** @type {string} */ (row.value)) : {};
+      // Let the validator fill in defaults
+      validate(configs[key]);
     }
     return configs;
   }

--- a/src/plugins/motd.js
+++ b/src/plugins/motd.js
@@ -12,9 +12,15 @@ class MOTD {
     this.#uw = uw;
 
     uw.config.register(CONFIG_MOTD, {
+      title: 'Message of the day',
+      description: 'Display a welcome message at the top of the chat when a user joins.',
       type: 'object',
       properties: {
-        text: { type: 'string', nullable: true },
+        text: {
+          title: 'Message',
+          type: 'string',
+          nullable: true,
+        },
       },
     });
   }

--- a/src/schemas/socialAuth.json
+++ b/src/schemas/socialAuth.json
@@ -58,5 +58,6 @@
       "default": {}
     }
   },
-  "required": ["google"]
+  "required": ["google"],
+  "default": {}
 }


### PR DESCRIPTION
Previously we'd just use an empty object, but this might not be a valid
value if the schema specifies required properties. If those required
properties have defaults, we can fill them in like this.

Also verify that an empty object is valid for every registered config schema,
so you can't have a schema that would cause errors when the client tries to render it.
